### PR TITLE
add outline of gao mateer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -840,6 +840,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "reed-solomon-gao-mateer"
+version = "1.0.1-alpha.0"
+dependencies = [
+ "assert_matches",
+ "derive_more",
+ "fs-err",
+ "itertools 0.10.0",
+ "rand",
+ "reed-solomon-erasure",
+ "reed-solomon-tester",
+ "static_init",
+ "thiserror",
+]
+
+[[package]]
 name = "reed-solomon-novelpoly"
 version = "1.0.1-alpha.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ debug = true
 members = [
      "./reed-solomon-tester",
      "./reed-solomon-novelpoly",
+     "./reed-solomon-gao-mateer",
      "./reed-solomon-novelpoly-fuzzit",
      "./reed-solomon-benches",
 ]

--- a/reed-solomon-gao-mateer/Cargo.toml
+++ b/reed-solomon-gao-mateer/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "reed-solomon-gao-mateer"
+version = "1.0.1-alpha.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+repository = "https://github.com/paritytech/reed-solomon-novelpoly"
+edition = "2018"
+license = "Apache-2.0 AND MIT"
+description = "An implementation of a reed solomon code / encoder / decoder with complexity `O(n lg(n))`"
+keywords = ["reed-solomon", "erasure", "encoding", "algorithm"]
+readme = "../README.md"
+
+[build-dependencies]
+derive_more = { version = "0.99.0", default-features = false, features = ["add_assign", "add"] }
+fs-err = "2.5.0"
+
+[dependencies]
+reed-solomon-erasure = { version = "4.0", features = ["simd-accel"], optional = true }
+static_init = "0.5.2"
+
+thiserror = "1.0.23"
+derive_more = { version = "0.99.0", default-features = false, features = ["add_assign", "add"] }
+itertools = "0.10.0"
+
+[dev-dependencies]
+reed-solomon-tester = { path = "../reed-solomon-tester" }
+rand = { version = "0.8.3", features = ["alloc", "small_rng"] }
+assert_matches = "1.5.0"

--- a/reed-solomon-gao-mateer/inc_gen_field_tables.rs
+++ b/reed-solomon-gao-mateer/inc_gen_field_tables.rs
@@ -1,0 +1,89 @@
+use std::io;
+use std::env;
+use std::fmt;
+use std::path::PathBuf;
+use fs_err as fs;
+
+/// Write Rust `const` declaration
+pub fn write_const<W, T>(mut w: W, name: &str, value: &T, type_name: &str) -> io::Result<()>
+where
+	W: io::Write,
+	T: fmt::Debug,
+{
+	writeln!(w, r###"#[allow(unused)]
+pub(crate) static {}: {} = {:#?};"###, name, type_name, value)
+}
+
+/// Compute tables determined solely by the field, which never depend
+/// upon the FFT domain or erasure coding paramaters.
+///
+/// We compute `LOG_TABLE` and `EXP_TABLE` here of course.  We compute
+/// the Walsh transform table `LOG_WALSH` here too because we never figured
+/// out how to shrink `LOG_WALSH` below the size of the full field (TODO).
+/// We thus assume it depends only upon the field for now.
+#[allow(unused)]
+fn write_field_tables<W: io::Write>(mut w: W) -> io::Result<()> {
+	let mut log_table: [Elt; FIELD_SIZE] = [0; FIELD_SIZE];
+	let mut exp_table: [Elt; FIELD_SIZE] = [0; FIELD_SIZE];
+
+	let mas: Elt = (1 << FIELD_BITS - 1) - 1;
+	let mut state: usize = 1;
+	for i in 0_usize..(ONEMASK as usize) {
+		exp_table[state] = i as Elt;
+		if (state >> FIELD_BITS - 1) != 0 {
+			state &= mas as usize;
+			state = state << 1_usize ^ GENERATOR as usize;
+		} else {
+			state <<= 1;
+		}
+	}
+	exp_table[0] = ONEMASK;
+
+	log_table[0] = 0;
+	for i in 0..FIELD_BITS {
+		for j in 0..(1 << i) {
+			log_table[j + (1 << i)] = log_table[j] ^ BASE[i];
+		}
+	}
+	for i in 0..FIELD_SIZE {
+		log_table[i] = exp_table[log_table[i] as usize];
+	}
+
+	for i in 0..FIELD_SIZE {
+		exp_table[log_table[i] as usize] = i as Elt;
+	}
+	exp_table[ONEMASK as usize] = exp_table[0];
+
+	write_const(&mut w, "LOG_TABLE", &log_table, "[Elt; FIELD_SIZE]")?;
+	write_const(&mut w, "EXP_TABLE", &exp_table, "[Elt; FIELD_SIZE]")?;
+
+	// mem_cpy(&mut log_walsh[..], &log_table[..]);
+	let log_walsh = log_table.clone();
+	let mut log_walsh = unsafe { core::mem::transmute::<_, [Multiplier; FIELD_SIZE]>(log_walsh) };
+	log_walsh[0] = Multiplier(0);
+	walsh(&mut log_walsh[..], FIELD_SIZE);
+
+	write_const(w, "LOG_WALSH", &log_walsh, "[Multiplier; FIELD_SIZE]")?;
+	Ok(())
+}
+
+/// Create tables file
+///
+/// We'll eventually need a seperate tables.rs build target because cargo
+/// dislikes build artifacts appearing outside env!("OUT_DIR") and we
+/// require tables to build other tables.
+/// ref.  https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script
+pub fn gen_field_tables() -> io::Result<()> {
+	// to avoid a circular loop, we need to import a dummy
+	// table, such that we do not depend on the thing we are
+	// about to spawn
+	println!("cargo:rustc-cfg=table_bootstrap_complete");
+
+	let out = env::var("OUT_DIR").expect("OUT_DIR is set by cargo after process launch. qed");
+
+	let path = PathBuf::from(out).join(format!("table_{}.rs", FIELD_NAME));
+	let f = fs::OpenOptions::new().create(true).truncate(true).write(true).open(path)?;
+	write_field_tables(f)?;
+
+	Ok(())
+}

--- a/reed-solomon-gao-mateer/src/errors.rs
+++ b/reed-solomon-gao-mateer/src/errors.rs
@@ -1,0 +1,28 @@
+/// Error type for interfacing with the novel poly basis
+#[non_exhaustive]
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+pub enum Error {
+	#[error("Number of wanted shards {0} exceeds max of 2^16")]
+	WantedShardCountTooHigh(usize),
+
+	#[error("Number of wanted shards must be at least 2, but is {0}")]
+	WantedShardCountTooLow(usize),
+
+	#[error("Number of wanted payload shards must be at least 1, but is {0}")]
+	WantedPayloadShardCountTooLow(usize),
+
+	#[error("Size of the payload is zero")]
+	PayloadSizeIsZero,
+
+	#[error("Needs at least {min} shards of {all} to recover, have {have}")]
+	NeedMoreShards { have: usize, min: usize, all: usize },
+
+	#[error("Parameters: n (= {n}) and k (= {k}) both must be a power of 2")]
+	ParamterMustBePowerOf2 { n: usize, k: usize },
+
+	#[error("Shards do have inconsistent lengths: first = {first}, other = {other})")]
+	InconsistentShardLengths { first: usize, other: usize },
+}
+
+/// Result alias to simplify API.
+pub type Result<T> = std::result::Result<T, Error>;

--- a/reed-solomon-gao-mateer/src/gao_mateer.rs
+++ b/reed-solomon-gao-mateer/src/gao_mateer.rs
@@ -1,0 +1,191 @@
+// let evaluated = fft::<Polynom, Field>(values: &[Field::Element]);
+
+
+pub type Ele = u16;
+
+trait ExtensionField {
+	const BITS: usize = 16;
+	type Element = Ele;
+}
+
+pub struct Polynom<F: ExtensionField> {
+	pub polynom: u16,
+}
+
+impl<F: ExtensionField> Polynom<F> {
+	pub const fn deg(&self) -> usize {
+		(u16::BITS - self.polynom.leading_ones()) as usize
+	}
+
+}
+
+impl<F: ExtensionField> std::ops::Add<Polynom<F>> for  Polynom<F> {
+	fn add(&self, other: Polynom) -> Self {
+		self.polynom ^= other.polynom;
+		self.clone()
+	}
+}
+
+impl<F: ExtensionField> std::ops::Mul<Polynom<F>> for Polynom<F> {
+	fn mul(&self, other: Polynom) -> Self {
+		// let mut acc = 0;
+		// for (idx, bit) in other.bits().enumerate() {
+		//     if bit == 1 { acc ^= (self.bits() << idx) }
+		// }
+		// self.polynom *= other.polynom;
+		self.clone()
+	}
+}
+
+
+type K = usize;
+
+type T = usize;
+const T: T = 2;
+
+#[inline(always)]
+fn lower(k: K, t: T) -> usize {
+	t * (1 << k)
+}
+
+#[inline(always)]
+fn upper(k: K, t: T) -> usize {
+	t * (1 << (k+1))
+}
+
+#[inline(always)]
+fn find_k_between(t: T, n: usize) -> K {
+	let mut k: K = log2(n) as K;
+	let mut next = k;
+	while lower(k, t) < n {
+		k = next;
+		next += 1;
+	}
+	while n <= upper(k, t) {
+		k = next;
+		next += 1;
+	}
+	k
+}
+
+// values is `B` in the paper
+fn fft_inner<F: ExtensionField>(f: Polynom<F>, m: usize, B: &[Ele]) -> Vec<Ele> {
+	let n  = 1_usize << m;
+	assert!(f.deg() < n);
+	if m == 1 {
+		return vec![
+			f.eval(0 as Ele),
+			f.eval(B[0]),
+		]
+	}
+
+	// TODO linearly independent vs what?
+	let betas = B;
+	let beta_m = betas[m];
+
+	// linear mapping of the polynomial
+	let g = f * beta_m;
+
+	let taylor = taylor_expansion(f, n, T);
+
+	// G
+	let gammas = Vec::from_iter(betas.into_iter().map(|beta| beta / beta_m));
+	// D
+	let sigmas = Vec::from_iter(gammas.into_iter().map(|gamma| gamma * gamma  - gamma));
+
+	let us = fft_inner(taylor.g0, m-1, sigmas);
+	let vs = fft_inner(taylor.g1, m-1, sigmas);
+
+	// FIXME is this `Ele` or just a bit?
+	const N_HALF: usize = n/2;
+	let mut ws  = [0 as Ele; N_HALF];
+	assert!(us.len() == k);
+	assert!(2 * k == ws.len());
+	for (i,(u,v)) in us.into_iter().zip(vs.into_iter).enumerate() {
+		ws[i] = u[i] + v[i] * betas[i];
+		ws[i + k] = ws[i] + v[i];
+	}
+	ws
+}
+
+
+/// Create a taylor expansion consisting of `f0` and `f1` at
+/// the point `x^t - x` with `t > 1`.
+///
+/// `n` is the number of ...
+pub fn taylor_expansion<F: FieldExtension>(f: Polynom<F>, n: usize, t: T) -> Polynom<F> {
+	assert!(f.deg() < n);
+
+	let k = find_k_between(t, n);
+
+	let [f0, f1, f2] = split_polynom(f, t, k);
+
+	// polynom domain ops
+	let h = f0 + f1;
+	let g0 = f0 + Polynom::x_at(1 << k) * h;
+	let g1 = h + Polynom::x_at((t-1)*(1 << k)) * h;
+
+	// recurse
+	let v1 = taylor_expansion(g0, t * (1<<k), t);
+	let v2 = taylor_expansion(g1, n - t * (1<<k), t);
+
+	// assumes a problem of for `n = 2^(k+1)`
+	v1 | (v2 << n/2)
+}
+
+
+
+struct PolySplit<F> {
+	f0: Polynom<F>,
+	f1: Polynom<F>,
+	f2: Polynom<F>,
+}
+
+fn split_polynom<F>(polynom: Polynom<F>, k: K, t: T) -> PolySplit<F> {
+	// assert!(T must be of 2^x!);
+
+	let mask0 = 1 << k; // deg f0 < 0..2^k
+	let mask2 = T * (1 << k); // deg f2 < t * 2^k
+	let mask1 = !mask0 & !mask2; // deg f1 < t * 2^k - 2^k
+
+	let mut f0 = polynom.clone();
+	f0.polynom &= mask0;
+
+	let mut f1 = polynom.clone();
+	f1.polynom &= mask1;
+
+	let mut f2 = polynom.clone();
+	f2.polynom &= mask2;
+
+	PolySplit { f0
+	, f1: (), f2: () }
+}
+
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn bounds_work() {
+		for k in 0..128 {
+			for t in 2..n {
+				assert!(lower(k,t) < upper(k,t));
+			}
+		}
+
+		assert_eq!(lower(16,2), 4);
+		assert_eq!(upper(16,2), 8);
+	}
+	#[test]
+	fn select_k() {
+		for z in 0..13 {
+			let n = 1 << z;
+			for t in 2..n {
+				let k = find_k_between(t, n);
+				assert!(n <= upper(k,t));
+				assert!(lower(k,t) < n);
+			}
+		}
+	}
+}

--- a/reed-solomon-gao-mateer/src/lib.rs
+++ b/reed-solomon-gao-mateer/src/lib.rs
@@ -1,0 +1,38 @@
+#![forbid(unused_crate_dependencies)]
+
+pub mod errors;
+pub use errors::*;
+
+pub mod util;
+pub use util::*;
+
+
+pub mod gao_mateer;
+
+pub mod shard;
+pub use self::shard::Shard;
+
+pub mod wrapped_shard;
+pub use self::wrapped_shard::WrappedShard;
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use reed_solomon_tester::{roundtrip, BYTES, N_SHARDS};
+
+	#[cfg(feature = "naive")]
+	#[test]
+	fn status_quo_roundtrip() -> Result<()> {
+		roundtrip(status_quo::encode::<WrappedShard>, status_quo::reconstruct::<WrappedShard>, &BYTES[..1337], N_SHARDS)
+	}
+
+	#[test]
+	fn novel_poly_basis_roundtrip() -> Result<()> {
+		roundtrip(
+			novel_poly_basis::encode::<WrappedShard>,
+			novel_poly_basis::reconstruct::<WrappedShard>,
+			&BYTES[..1337],
+			N_SHARDS,
+		)
+	}
+}

--- a/reed-solomon-gao-mateer/src/shard.rs
+++ b/reed-solomon-gao-mateer/src/shard.rs
@@ -1,0 +1,24 @@
+use std::iter;
+
+pub trait Shard:
+	Clone + AsRef<[u8]> + AsMut<[u8]> + AsMut<[[u8; 2]]> + AsRef<[[u8; 2]]> + iter::FromIterator<[u8; 2]> + From<Vec<u8>>
+{
+	type Inner;
+	fn into_inner(self) -> Self::Inner;
+}
+
+impl<T> Shard for T
+where
+	T: Clone
+		+ AsRef<[u8]>
+		+ AsMut<[u8]>
+		+ AsMut<[[u8; 2]]>
+		+ AsRef<[[u8; 2]]>
+		+ iter::FromIterator<[u8; 2]>
+		+ From<Vec<u8>>,
+{
+	type Inner = Self;
+	fn into_inner(self) -> Self::Inner {
+		self
+	}
+}

--- a/reed-solomon-gao-mateer/src/util.rs
+++ b/reed-solomon-gao-mateer/src/util.rs
@@ -1,0 +1,59 @@
+pub const fn log2(mut x: usize) -> usize {
+	let mut o: usize = 0;
+	while x > 1 {
+		x >>= 1;
+		o += 1;
+	}
+	o
+}
+
+/// Check if x is a power of 2.
+///
+/// Zero is by definition not a power of 2.
+pub const fn is_power_of_2(x: usize) -> bool {
+	x > 0_usize && x & (x - 1) == 0
+}
+
+/// Tick up to the next higher power of 2 if
+/// the provided number is not a power of 2.
+pub const fn next_higher_power_of_2(k: usize) -> usize {
+	if is_power_of_2(k) {
+		k
+	} else {
+		1 << (log2(k) + 1)
+	}
+}
+
+/// Tick down to the next higher power of 2 if
+/// the provided number is not a power of 2.
+pub const fn next_lower_power_of_2(k: usize) -> usize {
+	if is_power_of_2(k) {
+		k
+	} else {
+		1 << log2(k)
+	}
+}
+
+/// Does not care about power of 2 requirements.
+///
+/// Covers the 1/3 case.
+pub const fn recoverablity_subset_size(n_wanted_shards: usize) -> usize {
+	(n_wanted_shards.saturating_sub(1) / 3) + 1
+}
+
+#[test]
+fn three_f_plus_1() {
+	assert_eq!(recoverablity_subset_size(0), 1); // degenerate
+	assert_eq!(recoverablity_subset_size(1), 1);
+	assert_eq!(recoverablity_subset_size(2), 1);
+	assert_eq!(recoverablity_subset_size(3), 1);
+	assert_eq!(recoverablity_subset_size(4), 2);
+	assert_eq!(recoverablity_subset_size(5), 2);
+	assert_eq!(recoverablity_subset_size(6), 2);
+	assert_eq!(recoverablity_subset_size(8), 3);
+	assert_eq!(recoverablity_subset_size(11), 4);
+
+	assert_eq!(recoverablity_subset_size(173), 58);
+	assert_eq!(recoverablity_subset_size(174), 58);
+	assert_eq!(recoverablity_subset_size(175), 59);
+}

--- a/reed-solomon-gao-mateer/src/wrapped_shard.rs
+++ b/reed-solomon-gao-mateer/src/wrapped_shard.rs
@@ -1,0 +1,78 @@
+// A shard with a even number of elements, which can sliced into 2 byte haps
+#[derive(Clone, Debug)]
+pub struct WrappedShard {
+	inner: Vec<u8>,
+}
+
+impl WrappedShard {
+	/// Wrap `data`.
+	pub fn new(mut data: Vec<u8>) -> Self {
+		if data.len() & 0x01 == 0x01 {
+			data.push(0);
+		}
+
+		WrappedShard { inner: data }
+	}
+
+	/// Unwrap and yield inner data.
+	pub fn into_inner(self) -> Vec<u8> {
+		self.inner
+	}
+}
+
+impl From<Vec<u8>> for WrappedShard {
+	fn from(data: Vec<u8>) -> Self {
+		Self::new(data)
+	}
+}
+
+impl AsRef<[u8]> for WrappedShard {
+	fn as_ref(&self) -> &[u8] {
+		self.inner.as_ref()
+	}
+}
+
+impl AsMut<[u8]> for WrappedShard {
+	fn as_mut(&mut self) -> &mut [u8] {
+		self.inner.as_mut()
+	}
+}
+
+impl AsRef<[[u8; 2]]> for WrappedShard {
+	fn as_ref(&self) -> &[[u8; 2]] {
+		assert_eq!(self.inner.len() & 0x01, 0);
+		if self.inner.is_empty() {
+			return &[];
+		}
+		unsafe { ::std::slice::from_raw_parts(&self.inner[0] as *const _ as _, self.inner.len() / 2) }
+	}
+}
+
+impl AsMut<[[u8; 2]]> for WrappedShard {
+	fn as_mut(&mut self) -> &mut [[u8; 2]] {
+		let len = self.inner.len();
+		assert_eq!(len & 0x01, 0);
+
+		if self.inner.is_empty() {
+			return &mut [];
+		}
+		unsafe { ::std::slice::from_raw_parts_mut(&mut self.inner[0] as *mut _ as _, len / 2) }
+	}
+}
+
+impl std::iter::FromIterator<[u8; 2]> for WrappedShard {
+	fn from_iter<I: IntoIterator<Item = [u8; 2]>>(iterable: I) -> Self {
+		let iter = iterable.into_iter();
+
+		let (l, _) = iter.size_hint();
+		let mut inner = Vec::with_capacity(l * 2);
+
+		for [a, b] in iter {
+			inner.push(a);
+			inner.push(b);
+		}
+
+		debug_assert_eq!(inner.len() & 0x01, 0);
+		WrappedShard { inner }
+	}
+}

--- a/reed-solomon-gao-mateer/wrapper.h
+++ b/reed-solomon-gao-mateer/wrapper.h
@@ -1,0 +1,1 @@
+#include "cxx/RSErasureCode.h"


### PR DESCRIPTION
Since we have the huge upfront cost of the full walsh domain for the novel poly, the approach for gao mateer is definitely advantageous for `n <= 1024` despite the big O notation being `O(n * lg n  * lg n)` for `n = 2^m` and m _not_ being a power of 2 (which we have, but the current impl does not require). The variant for m being a power of two can achieve `O(n * lg n * lg lg n)` which for 1000 validators should provide us with an order of magnitude speedup. 

Next steps:

* [ ] Make it compile
* [ ] Obtain the `t` for our given generator polynomial 
* [ ] Impl the m is a power of 2
* [ ] Compare perf with @siddharthsinghal 's improve novel poly impl