### PR TITLE
chores: bump to edition 2021, update naiive crate dep, update criterion, fix `fn` ident

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -4,4 +4,4 @@ reorder_imports = false
 hard_tabs = true
 max_width = 120
 use_small_heuristics = "Max"
-edition = "2018"
+edition = "2021"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.14.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55f82cfe485775d02112886f4169bde0c5894d75e79ead7eafe7e40a25e45f7"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
 dependencies = [
  "gimli",
 ]
@@ -18,28 +18,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.15"
+name = "ahash"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "memchr",
+ "getrandom",
+ "once_cell",
+ "version_check",
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.11.0"
+name = "anes"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi",
-]
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
 
 [[package]]
 name = "arbitrary"
-version = "1.0.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "698b65a961a9d730fb45b6b0327e20207810c9f61ee421b082b27ba003f49e2b"
+checksum = "e2d098ff73c1ca148721f37baad5ea6a465a13f9573aba8641fbbbae8164a54e"
 dependencies = [
  "derive_arbitrary",
 ]
@@ -51,29 +56,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.56"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d117600f438b1707d4e4ae15d3595657288f8235a0eb593e80ecc98ab34e1bc"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
 dependencies = [
  "addr2line",
+ "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
@@ -83,80 +78,65 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.57.0"
+version = "0.66.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd4865004a46a0aafb2a0a5eb19d3c9fc46ee5f063a6cfc605c69ac9ecf5263d"
+checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
 dependencies = [
- "bitflags",
+ "bitflags 2.3.3",
  "cexpr",
  "clang-sys",
- "clap",
- "env_logger",
  "lazy_static",
  "lazycell",
  "log",
  "peeking_take_while",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
+ "syn 2.0.22",
  "which",
 ]
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bstr"
-version = "0.2.15"
+name = "bitflags"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a40b47ad93e1a5404e6c18dec46b628214fee441c70f4ab5d6942142cc268a3d"
-dependencies = [
- "lazy_static",
- "memchr",
- "regex-automata",
- "serde",
-]
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
 name = "bumpalo"
-version = "3.6.1"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
-
-[[package]]
-name = "byteorder"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "cast"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0"
-dependencies = [
- "rustc_version",
-]
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.67"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 dependencies = [
  "jobserver",
 ]
 
 [[package]]
 name = "cexpr"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
  "nom",
 ]
@@ -174,10 +154,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
-name = "clang-sys"
-version = "1.1.1"
+name = "ciborium"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f54d78e30b388d4815220c8dd03fea5656b6c6d32adb59e89061552a102f8da1"
+checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
 dependencies = [
  "glob",
  "libc",
@@ -186,24 +193,35 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "4.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "d9394150f5b4273a1763355bd1c2ec54cc5a2593f790587bcd6b2c947cfa9211"
 dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim",
- "textwrap",
- "unicode-width",
- "vec_map",
+ "clap_builder",
 ]
 
 [[package]]
-name = "color-eyre"
-version = "0.5.10"
+name = "clap_builder"
+version = "4.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b29030875fd8376e4a28ef497790d5b4a7843d8d1396bf08ce46f5eec562c5c"
+checksum = "9a78fbdd3cc2914ddf37ba444114bc7765bbdcb55ec9cbe6fa054f0137400717"
+dependencies = [
+ "anstyle",
+ "bitflags 1.3.2",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+
+[[package]]
+name = "color-eyre"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a667583cca8c4f8436db8de46ea8233c42a7d9ae424a82d338f2e4675229204"
 dependencies = [
  "backtrace",
  "color-spantrace",
@@ -216,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "color-spantrace"
-version = "0.1.6"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6eee477a4a8a72f4addd4de416eb56d54bc307b284d6601bafdee1f4ea462d1"
+checksum = "1ba75b3d9449ecdccb27ecbc479fdc0b87fa2dd43d2f8298f9bf0e59aacc8dce"
 dependencies = [
  "once_cell",
  "owo-colors",
@@ -228,24 +246,24 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.3.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab327ed7354547cc2ef43cbe20ef68b988e70b4b593cbd66a2a61733123a3d23"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
 dependencies = [
- "atty",
+ "anes",
  "cast",
+ "ciborium",
  "clap",
  "criterion-plot",
- "csv",
- "itertools 0.10.0",
- "lazy_static",
+ "is-terminal",
+ "itertools 0.10.5",
  "num-traits",
+ "once_cell",
  "oorandom",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_cbor",
  "serde_derive",
  "serde_json",
  "tinytemplate",
@@ -254,19 +272,19 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e022feadec601fba1649cfa83586381a4ad31c6bf3a9ab7d408118b05dd9889d"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools 0.9.0",
+ "itertools 0.10.5",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.0"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -274,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -285,96 +303,80 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.3"
+version = "0.9.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2584f639eb95fea8c798496315b297cf81b9b58b6d30ab066a75455333cf4b12"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
 dependencies = [
+ "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "lazy_static",
  "memoffset",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.3"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
- "autocfg",
  "cfg-if",
- "lazy_static",
-]
-
-[[package]]
-name = "csv"
-version = "1.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
-dependencies = [
- "bstr",
- "csv-core",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
 name = "derive_arbitrary"
-version = "1.0.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df89dd0d075dea5cc5fdd6d5df6b8a61172a710b3efac1d6bdb9dd8b78f82c1a"
+checksum = "53e0efad4403bfc52dc201159c4b842a246a14b98c64b55dfd0f2d89729dfeb8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.22",
 ]
 
 [[package]]
 name = "derive_more"
-version = "0.99.11"
+version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cb0e6161ad61ed084a36ba71fbba9e3ac5aee3606fb607fe08da6acbcf3d8c"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
-name = "env_logger"
-version = "0.8.3"
+name = "errno"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
+ "errno-dragonfly",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
 name = "eyre"
-version = "0.6.5"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "221239d1d5ea86bf5d6f91c9d6bc3646ffe471b08ff9b0f91c44f115ac969d2b"
+checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
 dependencies = [
  "indenter",
  "once_cell",
@@ -382,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "fs-err"
-version = "2.5.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcd1163ae48bda72a20ae26d66a04d3094135cadab911cff418ae5e33f253431"
+checksum = "0845fa252299212f0389d64ba26f34fa32cfe41588355f21ed507c59a0f64541"
 
 [[package]]
 name = "fuzzit"
@@ -400,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.2"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
@@ -411,30 +413,45 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.23.0"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "glob"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "half"
-version = "1.7.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.18"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "honggfuzz"
@@ -446,12 +463,6 @@ dependencies = [
  "lazy_static",
  "memmap",
 ]
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "iai"
@@ -467,51 +478,74 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "instant"
-version = "0.1.9"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
-name = "itertools"
-version = "0.9.0"
+name = "io-lifetimes"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "0.4.7"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "jobserver"
-version = "0.1.21"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.49"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc15e39392125075f60c95ba416f5381ff6c3a948ff02ab12464715adf56c821"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -530,43 +564,62 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.88"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b07a082330a35e43f63177cc01689da34fbffa0105e1246cf0311472cac73a"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libloading"
-version = "0.7.0"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f84d96438c15fcd6c3f244c8fce01d1e2b9c6b5623e9c711dc9286d8fc92d6a"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
  "winapi",
 ]
 
 [[package]]
-name = "lock_api"
-version = "0.4.2"
+name = "libm"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
+checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+
+[[package]]
+name = "lock_api"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
+ "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+
+[[package]]
+name = "lru"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
 dependencies = [
- "cfg-if",
+ "hashbrown",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memmap"
@@ -580,63 +633,71 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.6.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc14fc54a812b4472b4113facc3e44d099fbc0ea2ce0551fa5c703f8edfbfd38"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
-name = "miniz_oxide"
-version = "0.4.4"
+name = "minimal-lexical"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
 dependencies = [
  "adler",
- "autocfg",
 ]
 
 [[package]]
 name = "nom"
-version = "5.1.2"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
- "version_check",
+ "minimal-lexical",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
 [[package]]
 name = "object"
-version = "0.23.0"
+version = "0.30.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
+checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "once_cell"
-version = "1.7.2"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "oorandom"
@@ -646,15 +707,15 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "owo-colors"
-version = "1.4.2"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f27ef240f1cbbcdc0774a634db63dde96db624aa010aceebccc2bb8a9a0cb67"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
@@ -663,9 +724,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.3"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
 dependencies = [
  "cfg-if",
  "instant",
@@ -683,15 +744,15 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.6"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "plotters"
-version = "0.3.0"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ca0ae5f169d0917a7c7f5a9c1a3d3d9598f18f529dd2b8373ed988efea307a"
+checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -702,60 +763,69 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.0"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b07fffcddc1cb3a1de753caa4e4df03b79922ba43cf882acc1bdd7e8df9f4590"
+checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.0"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b38a02e23bd9604b842a812063aec4ef702b57989c37b655254bb61c471ad211"
+checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
 dependencies = [
  "plotters-backend",
 ]
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.10"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9825a04601d60621feed79c4e6b56d65db77cdca55cef43b46b0de1096d1c282"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.22",
+]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rand"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
  "rand_core",
- "rand_hc",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -763,54 +833,42 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
-name = "rand_hc"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
 name = "rayon"
-version = "1.5.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
 dependencies = [
- "autocfg",
- "crossbeam-deque",
  "either",
  "rayon-core",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.9.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "lazy_static",
  "num_cpus",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.5"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -821,7 +879,7 @@ dependencies = [
  "color-eyre",
  "criterion",
  "iai",
- "itertools 0.10.0",
+ "itertools 0.11.0",
  "rand",
  "reed-solomon-erasure",
  "reed-solomon-novelpoly",
@@ -830,13 +888,17 @@ dependencies = [
 
 [[package]]
 name = "reed-solomon-erasure"
-version = "4.0.2"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a415a013dd7c5d4221382329a5a3482566da675737494935cbbbcdec04662f9d"
+checksum = "7263373d500d4d4f505d43a2a662d475a894aa94503a1ee28e9188b5f3960d4f"
 dependencies = [
  "cc",
  "libc",
+ "libm",
+ "lru",
+ "parking_lot",
  "smallvec",
+ "spin",
 ]
 
 [[package]]
@@ -848,7 +910,7 @@ dependencies = [
  "cc",
  "derive_more",
  "fs-err",
- "itertools 0.10.0",
+ "itertools 0.11.0",
  "rand",
  "reed-solomon-erasure",
  "reed-solomon-tester",
@@ -862,42 +924,30 @@ version = "0.1.0"
 dependencies = [
  "assert_matches",
  "fs-err",
- "itertools 0.10.0",
+ "itertools 0.11.0",
  "rand",
 ]
 
 [[package]]
 name = "regex"
-version = "1.4.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
- "aho-corasick",
- "memchr",
  "regex-syntax",
- "thread_local",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
-dependencies = [
- "byteorder",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.22"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.18"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc-hash"
@@ -906,19 +956,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustc_version"
-version = "0.2.3"
+name = "rustix"
+version = "0.37.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
 dependencies = [
- "semver",
+ "bitflags 1.3.2",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "same-file"
@@ -936,52 +991,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-
-[[package]]
 name = "serde"
-version = "1.0.125"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
-
-[[package]]
-name = "serde_cbor"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e18acfa2f90e8b735b2836ab8d538de304cbb6729a7360729ea5a895d15a622"
+checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 dependencies = [
- "half",
- "serde",
+ "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.125"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.22",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.64"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
 dependencies = [
  "itoa",
  "ryu",
@@ -990,111 +1023,108 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.1"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c719719ee05df97490f80a45acfc99e5a30ce98a1e4fb67aee422745ae14e3"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
 ]
 
 [[package]]
 name = "shlex"
-version = "0.1.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
+checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "smallvec"
-version = "1.6.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "static_init"
-version = "0.5.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11b73400442027c4adedda20a9f9b7945234a5bd8d5f7e86da22bd5d0622369c"
+checksum = "8a2a1c578e98c1c16fc3b8ec1328f7659a500737d7a0c6d625e73e830ff9c1f6"
 dependencies = [
+ "bitflags 1.3.2",
  "cfg_aliases",
  "libc",
  "parking_lot",
+ "parking_lot_core",
  "static_init_macro",
+ "winapi",
 ]
 
 [[package]]
 name = "static_init_macro"
-version = "0.5.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2261c91034a1edc3fc4d1b80e89d82714faede0515c14a75da10cb941546bbf"
+checksum = "70a2595fc3aa78f2d0e45dd425b22282dd863273761cc77780914b2cf3003acf"
 dependencies = [
  "cfg_aliases",
  "memchr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
-
-[[package]]
-name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.63"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd9bc7ccc2688b3344c2f48b9b546648b25ce0b20fc717ee7fa7981a8ca9717"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.1.2"
+name = "syn"
+version = "2.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "2efbeae7acf4eabd6bcdcbd11c92f45231ddda7539edc7806bd1a04a03b24616"
 dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.24"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.24"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.22",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.3"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
+ "cfg-if",
  "once_cell",
 ]
 
@@ -1110,41 +1140,30 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.25"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ebdc2bb4498ab1ab5f5b73c5803825e60199229ccba0698170e3be0e7f959f"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
 ]
 
 [[package]]
-name = "tracing-attributes"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "tracing-core"
-version = "0.1.17"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
+checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
- "lazy_static",
+ "once_cell",
+ "valuable",
 ]
 
 [[package]]
 name = "tracing-error"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4d7c0b83d4a500748fa5879461652b361edf5c9d51ede2a2ac03875ca185e24"
+checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -1152,9 +1171,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.17"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705096c6f83bf68ea5d357a6aa01829ddbdac531b357b45abeca842938085baa"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
  "sharded-slab",
  "thread_local",
@@ -1162,51 +1181,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-width"
-version = "0.1.8"
+name = "unicode-ident"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.1"
+name = "valuable"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
 dependencies = [
  "same-file",
- "winapi",
  "winapi-util",
 ]
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.72"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe8f61dba8e5d645a4d8132dc7a0a66861ed5e1045d2c0ed940fab33bac0fbe"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1214,24 +1226,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.72"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046ceba58ff062da072c7cb4ba5b22a37f00a302483f7e2a6cdc18fedbdc1fd3"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.22",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.72"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9aa01d36cda046f797c57959ff5f3c615c9cc63997a8d545831ec7976819b"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1239,28 +1251,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.72"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96eb45c1b2ee33545a813a92dbb53856418bf7eb54ab34f7f7ff1448a5b3735d"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.22",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.72"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7148f4696fb4960a346eaa60bbfb42a1ac4ebba21f750f75fc1375b098d5ffa"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "web-sys"
-version = "0.3.49"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fe19d70f5dacc03f6e46777213facae5ac3801575d56ca6cbd4c93dcd12310"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1268,11 +1280,13 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "3.1.1"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
 dependencies = [
+ "either",
  "libc",
+ "once_cell",
 ]
 
 [[package]]
@@ -1305,3 +1319,69 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"

--- a/reed-solomon-benches/Cargo.toml
+++ b/reed-solomon-benches/Cargo.toml
@@ -2,27 +2,30 @@
 name = "reed-solomon-benches"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]
-reed-solomon-erasure = { version = "4.0", features = ["simd-accel"], optional = true }
+reed-solomon-erasure = { version = "6.0.0", features = ["simd-accel"], optional = true }
 reed-solomon-novelpoly = { package = "reed-solomon-novelpoly", path = "../reed-solomon-novelpoly" }
 reed-solomon-tester = { package = "reed-solomon-tester", path = "../reed-solomon-tester" }
 
-color-eyre = "0.5"
+color-eyre = "0.6"
 
 rand = { version = "0.8", features = ["alloc", "small_rng"] }
-itertools = "0.10"
+itertools = "0.11"
 assert_matches = "1"
 
 [dev-dependencies]
 iai = "0.1"
-criterion = "0.3"
+criterion = "0.5"
+
+[[bench]]
+name = "criterion"
+harness = false
 
 [features]
 default = []
 novelpoly-cxx = ["reed-solomon-novelpoly/with-alt-cxx-impl"]
 naive = ["reed-solomon-erasure"]
 upperbounds=["naive"]
-

--- a/reed-solomon-novelpoly-fuzzit/Cargo.toml
+++ b/reed-solomon-novelpoly-fuzzit/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fuzzit"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/reed-solomon-novelpoly/Cargo.toml
+++ b/reed-solomon-novelpoly/Cargo.toml
@@ -3,7 +3,7 @@ name = "reed-solomon-novelpoly"
 version = "1.0.1-alpha.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/reed-solomon-novelpoly"
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0 AND MIT"
 description = "An implementation of a reed solomon code / encoder / decoder with complexity `O(n lg(n))`"
 keywords = ["reed-solomon", "erasure", "encoding", "algorithm"]
@@ -12,16 +12,16 @@ readme = "../README.md"
 [build-dependencies]
 derive_more = { version = "0.99.0", default-features = false, features = ["add_assign", "add"] }
 fs-err = "2.5.0"
-bindgen = { version = "0.57.0", optional = true }
+bindgen = { version = "0.66.1", optional = true }
 cc = { version = "1.0.67", features = ["parallel"], optional = true }
 
 [dependencies]
-reed-solomon-erasure = { version = "4.0", features = ["simd-accel"], optional = true }
-static_init = "0.5.2"
+reed-solomon-erasure = { version = "6.0", features = ["simd-accel"], optional = true }
+static_init = "1"
 
 thiserror = "1.0.23"
 derive_more = { version = "0.99.0", default-features = false, features = ["add_assign", "add"] }
-itertools = "0.10.0"
+itertools = "0.11.0"
 
 [dev-dependencies]
 reed-solomon-tester = { path = "../reed-solomon-tester" }

--- a/reed-solomon-tester/Cargo.toml
+++ b/reed-solomon-tester/Cargo.toml
@@ -2,7 +2,7 @@
 name = "reed-solomon-tester"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [build-dependencies]
@@ -11,5 +11,5 @@ fs-err = "2"
 
 [dependencies]
 rand = { version = "0.8", features = ["alloc", "small_rng"] }
-itertools = "0.10"
+itertools = "0.11"
 assert_matches = "1"


### PR DESCRIPTION
Also fixes a compilation issue, besides the chores.

---

Benchmarking outcome (`cargo criterion`) with `rustc 1.69.0 (84c898d65 2023-04-16)`

```
# cpuinfo
..
Brand Raw: AMD Ryzen 9 5950X 16-Core Processor
Hz Advertised Friendly: 2.2000 GHz
Hz Actual Friendly: 2.2000 GHz
Hz Advertised: (2200000000, 0)
Hz Actual: (2200000000, 0)
Arch: X86_64
Bits: 64
Count: 32
Arch String Raw: x86_64
L1 Data Cache Size: 524288
L1 Instruction Cache Size: 524288
L2 Cache Size: 8388608
L2 Cache Line Size: 512
L2 Cache Associativity: 6
L3 Cache Size: 524288
..
```


```
Benchmarking parameterized encode validator_count=4/novel-poly-encode/1000: Collecting 10 samples in estimated 5.0006 s (293k                                                                                                                               parameterized encode validator_count=4/novel-poly-encode/1000                        
                        time:   [16.722 µs 16.963 µs 17.150 µs]
                        change: [+0.5241% +2.0545% +3.8009%] (p = 0.04 < 0.05)
                        Change within noise threshold.
Benchmarking parameterized encode validator_count=4/novel-poly-encode/1112000: Collecting 10 samples in estimated 5.1209 s (22                                                                                                                              parameterized encode validator_count=4/novel-poly-encode/1112000                        
                        time:   [19.322 ms 19.518 ms 19.685 ms]
                        change: [+5.2683% +6.0682% +6.7714%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking parameterized encode validator_count=4/novel-poly-encode/2223000: Collecting 10 samples in estimated 7.2301 s (16                                                                                                                              parameterized encode validator_count=4/novel-poly-encode/2223000                        
                        time:   [37.033 ms 37.366 ms 37.921 ms]
                        change: [+0.0520% +1.0367% +2.1919%] (p = 0.09 > 0.05)
                        No change in performance detected.
Benchmarking parameterized encode validator_count=4/novel-poly-encode/3334000: Collecting 10 samples in estimated 6.5799 s (11                                                                                                                              parameterized encode validator_count=4/novel-poly-encode/3334000                        
                        time:   [57.612 ms 58.083 ms 58.632 ms]
                        change: [-0.2785% +0.8038% +2.0830%] (p = 0.22 > 0.05)
                        No change in performance detected.
Benchmarking parameterized encode validator_count=4/novel-poly-encode/4445000: Collecting 10 samples in estimated 9.4046 s (11                                                                                                                              parameterized encode validator_count=4/novel-poly-encode/4445000                        
                        time:   [77.552 ms 77.965 ms 78.540 ms]
                        change: [+1.1110% +1.8591% +2.6149%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking parameterized encode validator_count=4/novel-poly-encode/5556000: Warming up for 100.00 ms
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 6.8s or enable flat sampling.
Benchmarking parameterized encode validator_count=4/novel-poly-encode/5556000: Collecting 10 samples in estimated 6.8484 s (55                                                                                                                              parameterized encode validator_count=4/novel-poly-encode/5556000                        
                        time:   [96.945 ms 97.266 ms 97.532 ms]
                        change: [-2.4814% -1.9861% -1.5898%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking parameterized encode validator_count=4/novel-poly-encode/6667000: Warming up for 100.00 ms
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 7.9s or enable flat sampling.
Benchmarking parameterized encode validator_count=4/novel-poly-encode/6667000: Collecting 10 samples in estimated 7.9028 s (55                                                                                                                              parameterized encode validator_count=4/novel-poly-encode/6667000                        
                        time:   [115.93 ms 116.13 ms 116.39 ms]
                        change: [-2.4880% -2.1258% -1.7894%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking parameterized encode validator_count=4/novel-poly-encode/7778000: Warming up for 100.00 ms
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 9.0s or enable flat sampling.
Benchmarking parameterized encode validator_count=4/novel-poly-encode/7778000: Collecting 10 samples in estimated 9.0187 s (55                                                                                                                              parameterized encode validator_count=4/novel-poly-encode/7778000                        
                        time:   [136.52 ms 136.78 ms 137.04 ms]
                        change: [-0.4451% -0.2491% -0.0643%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Benchmarking parameterized encode validator_count=4/novel-poly-encode/8889000: Warming up for 100.00 ms
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 9.6s or enable flat sampling.
Benchmarking parameterized encode validator_count=4/novel-poly-encode/8889000: Collecting 10 samples in estimated 9.5897 s (55                                                                                                                              parameterized encode validator_count=4/novel-poly-encode/8889000                        
                        time:   [157.35 ms 157.57 ms 157.98 ms]
                        change: [+0.7741% +1.9449% +3.2533%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking parameterized encode validator_count=36/novel-poly-encode/1000: Collecting 10 samples in estimated 5.0011 s (89k                                                                                                                               parameterized encode validator_count=36/novel-poly-encode/1000                        
                        time:   [45.528 µs 45.797 µs 45.928 µs]
                        change: [-3.1655% -2.2019% -1.3332%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking parameterized encode validator_count=36/novel-poly-encode/1112000: Collecting 10 samples in estimated 6.0395 s (1                                                                                                                              parameterized encode validator_count=36/novel-poly-encode/1112000                        
                        time:   [49.856 ms 50.014 ms 50.093 ms]
                        change: [+2.3664% +2.7480% +3.1038%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking parameterized encode validator_count=36/novel-poly-encode/2223000: Warming up for 100.00 ms
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 6.4s or enable flat sampling.
Benchmarking parameterized encode validator_count=36/novel-poly-encode/2223000: Collecting 10 samples in estimated 6.4015 s (5                                                                                                                              parameterized encode validator_count=36/novel-poly-encode/2223000                        
                        time:   [98.148 ms 99.758 ms 100.76 ms]
                        change: [-5.0153% -0.8448% +2.0502%] (p = 0.77 > 0.05)
                        No change in performance detected.
Benchmarking parameterized encode validator_count=36/novel-poly-encode/3334000: Warming up for 100.00 ms
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.2s or enable flat sampling.
Benchmarking parameterized encode validator_count=36/novel-poly-encode/3334000: Collecting 10 samples in estimated 8.2420 s (5                                                                                                                              parameterized encode validator_count=36/novel-poly-encode/3334000                        
                        time:   [142.82 ms 143.05 ms 143.32 ms]
                        change: [-13.079% -10.629% -8.7149%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking parameterized encode validator_count=36/novel-poly-encode/4445000: Collecting 10 samples in estimated 6.4795 s (3                                                                                                                              parameterized encode validator_count=36/novel-poly-encode/4445000                        
                        time:   [189.68 ms 190.79 ms 192.15 ms]
                        change: [-15.914% -13.855% -11.858%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking parameterized encode validator_count=36/novel-poly-encode/5556000: Collecting 10 samples in estimated 5.5400 s (2                                                                                                                              parameterized encode validator_count=36/novel-poly-encode/5556000                        
                        time:   [241.83 ms 246.04 ms 249.97 ms]
                        change: [-15.387% -10.133% -5.1149%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking parameterized encode validator_count=36/novel-poly-encode/6667000: Collecting 10 samples in estimated 6.7533 s (2                                                                                                                              parameterized encode validator_count=36/novel-poly-encode/6667000                        
                        time:   [309.61 ms 310.57 ms 311.76 ms]
                        change: [-3.7559% -1.4396% +0.5581%] (p = 0.25 > 0.05)
                        No change in performance detected.
Benchmarking parameterized encode validator_count=36/novel-poly-encode/7778000: Collecting 10 samples in estimated 7.6389 s (2                                                                                                                              parameterized encode validator_count=36/novel-poly-encode/7778000                        
                        time:   [354.49 ms 361.17 ms 367.70 ms]
                        change: [-3.4939% -0.7453% +1.8371%] (p = 0.60 > 0.05)
                        No change in performance detected.
Benchmarking parameterized encode validator_count=36/novel-poly-encode/8889000: Collecting 10 samples in estimated 8.4624 s (2                                                                                                                              parameterized encode validator_count=36/novel-poly-encode/8889000                        
                        time:   [411.75 ms 416.14 ms 420.64 ms]
                        change: [-1.2526% +0.1072% +1.5363%] (p = 0.89 > 0.05)
                        No change in performance detected.

Benchmarking parameterized encode validator_count=68/novel-poly-encode/1000: Collecting 10 samples in estimated 5.0027 s (93k                                                                                                                               parameterized encode validator_count=68/novel-poly-encode/1000                        
                        time:   [46.175 µs 46.338 µs 46.560 µs]
                        change: [-3.5639% -2.8518% -2.1735%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking parameterized encode validator_count=68/novel-poly-encode/1112000: Collecting 10 samples in estimated 6.3791 s (1                                                                                                                              parameterized encode validator_count=68/novel-poly-encode/1112000                        
                        time:   [49.436 ms 49.507 ms 49.619 ms]
                        change: [+0.9403% +1.3299% +1.7242%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Benchmarking parameterized encode validator_count=68/novel-poly-encode/2223000: Warming up for 100.00 ms
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 6.8s or enable flat sampling.
Benchmarking parameterized encode validator_count=68/novel-poly-encode/2223000: Collecting 10 samples in estimated 6.7596 s (5                                                                                                                              parameterized encode validator_count=68/novel-poly-encode/2223000                        
                        time:   [93.588 ms 94.620 ms 95.911 ms]
                        change: [+3.7973% +5.3233% +6.8524%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking parameterized encode validator_count=68/novel-poly-encode/3334000: Warming up for 100.00 ms
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 9.0s or enable flat sampling.
Benchmarking parameterized encode validator_count=68/novel-poly-encode/3334000: Collecting 10 samples in estimated 9.0062 s (55 iterations)^R
                                                                                                                              parameterized encode validator_count=68/novel-poly-encode/3334000                        
                        time:   [145.75 ms 148.85 ms 153.16 ms]
                        change: [+3.0856% +4.4821% +5.7710%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking parameterized encode validator_count=68/novel-poly-encode/4445000: Collecting 10 samples in estimated 6.7432 s (3                                                                                                                              parameterized encode validator_count=68/novel-poly-encode/4445000                        
                        time:   [200.00 ms 200.84 ms 201.80 ms]
                        change: [+3.3519% +3.7826% +4.2490%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking parameterized encode validator_count=68/novel-poly-encode/5556000: Collecting 10 samples in estimated 5.2248 s (2                                                                                                                              parameterized encode validator_count=68/novel-poly-encode/5556000                        
                        time:   [242.64 ms 243.07 ms 243.60 ms]
                        change: [+0.7049% +0.9216% +1.1581%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Benchmarking parameterized encode validator_count=68/novel-poly-encode/6667000: Collecting 10 samples in estimated 6.7614 s (2                                                                                                                              parameterized encode validator_count=68/novel-poly-encode/6667000                        
                        time:   [306.07 ms 307.30 ms 308.46 ms]
                        change: [+5.4876% +5.9848% +6.4633%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking parameterized encode validator_count=68/novel-poly-encode/7778000: Collecting 10 samples in estimated 7.6280 s (2                                                                                                                              parameterized encode validator_count=68/novel-poly-encode/7778000                        
                        time:   [358.76 ms 360.55 ms 362.24 ms]
                        change: [+6.2508% +7.3632% +8.5280%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking parameterized encode validator_count=68/novel-poly-encode/8889000: Collecting 10 samples in estimated 8.2244 s (2                                                                                                                              parameterized encode validator_count=68/novel-poly-encode/8889000                        
                        time:   [391.46 ms 397.25 ms 403.24 ms]
                        change: [+3.9687% +6.0201% +7.9434%] (p = 0.00 < 0.05)
                        Performance has regressed.

Benchmarking parameterized reconstruct validator_count=4/novel-poly-reconstruct/1000: Collecting 10 samples in estimated 5.000                                                                                                                              parameterized reconstruct validator_count=4/novel-poly-reconstruct/1000                        
                        time:   [239.71 ns 240.80 ns 242.18 ns]
                        change: [-2.0552% -1.4975% -0.8930%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Benchmarking parameterized reconstruct validator_count=4/novel-poly-reconstruct/1112000: Collecting 10 samples in estimated 5.                                                                                                                              parameterized reconstruct validator_count=4/novel-poly-reconstruct/1112000                        
                        time:   [39.200 µs 39.650 µs 40.206 µs]
                        change: [-3.0420% -2.3719% -1.5411%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking parameterized reconstruct validator_count=4/novel-poly-reconstruct/2223000: Collecting 10 samples in estimated 5.                                                                                                                              parameterized reconstruct validator_count=4/novel-poly-reconstruct/2223000                        
                        time:   [76.361 µs 77.501 µs 78.470 µs]
                        change: [-2.7765% -1.6878% -0.3629%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Benchmarking parameterized reconstruct validator_count=4/novel-poly-reconstruct/3334000: Collecting 10 samples in estimated 5.                                                                                                                              parameterized reconstruct validator_count=4/novel-poly-reconstruct/3334000                        
                        time:   [116.97 µs 118.91 µs 120.30 µs]
                        change: [-4.2815% -2.3385% -0.1685%] (p = 0.06 > 0.05)
                        No change in performance detected.
Benchmarking parameterized reconstruct validator_count=4/novel-poly-reconstruct/4445000: Collecting 10 samples in estimated 5.                                                                                                                              parameterized reconstruct validator_count=4/novel-poly-reconstruct/4445000                        
                        time:   [164.34 µs 166.60 µs 168.37 µs]
                        change: [+2.1989% +4.1996% +6.5536%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking parameterized reconstruct validator_count=4/novel-poly-reconstruct/5556000: Collecting 10 samples in estimated 5.                                                                                                                              parameterized reconstruct validator_count=4/novel-poly-reconstruct/5556000                        
                        time:   [225.09 µs 228.39 µs 232.24 µs]
                        change: [+3.3934% +6.0691% +9.0504%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking parameterized reconstruct validator_count=4/novel-poly-reconstruct/6667000: Collecting 10 samples in estimated 5.                                                                                                                              parameterized reconstruct validator_count=4/novel-poly-reconstruct/6667000                        
                        time:   [316.39 µs 320.42 µs 323.10 µs]
                        change: [-0.5720% +2.7308% +5.8608%] (p = 0.12 > 0.05)
                        No change in performance detected.
Benchmarking parameterized reconstruct validator_count=4/novel-poly-reconstruct/7778000: Collecting 10 samples in estimated 5.                                                                                                                              parameterized reconstruct validator_count=4/novel-poly-reconstruct/7778000                        
                        time:   [2.2722 ms 2.2900 ms 2.3265 ms]
                        change: [+416.77% +430.28% +445.18%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking parameterized reconstruct validator_count=4/novel-poly-reconstruct/8889000: Collecting 10 samples in estimated 5.                                                                                                                              parameterized reconstruct validator_count=4/novel-poly-reconstruct/8889000                        
                        time:   [3.2475 ms 3.2885 ms 3.3559 ms]
                        change: [+31.146% +33.674% +36.508%] (p = 0.00 < 0.05)
                        Performance has regressed.

Benchmarking parameterized reconstruct validator_count=36/novel-poly-reconstruct/1000: Collecting 10 samples in estimated 5.02                                                                                                                              parameterized reconstruct validator_count=36/novel-poly-reconstruct/1000                        
                        time:   [861.14 µs 863.36 µs 865.03 µs]
                        change: [+0.7473% +1.9859% +3.1206%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Benchmarking parameterized reconstruct validator_count=36/novel-poly-reconstruct/1112000: Collecting 10 samples in estimated 8                                                                                                                              parameterized reconstruct validator_count=36/novel-poly-reconstruct/1112000                        
                        time:   [76.569 ms 78.296 ms 79.430 ms]
                        change: [+1.3487% +2.6240% +4.1985%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking parameterized reconstruct validator_count=36/novel-poly-reconstruct/2223000: Warming up for 100.00 ms
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.5s or enable flat sampling.
Benchmarking parameterized reconstruct validator_count=36/novel-poly-reconstruct/2223000: Collecting 10 samples in estimated 8                                                                                                                              parameterized reconstruct validator_count=36/novel-poly-reconstruct/2223000                        
                        time:   [154.61 ms 154.96 ms 155.43 ms]
                        change: [+0.2407% +0.7631% +1.3913%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Benchmarking parameterized reconstruct validator_count=36/novel-poly-reconstruct/3334000: Collecting 10 samples in estimated 6                                                                                                                              parameterized reconstruct validator_count=36/novel-poly-reconstruct/3334000                        
                        time:   [230.69 ms 233.32 ms 235.92 ms]
                        change: [-1.3023% +0.2524% +1.5953%] (p = 0.75 > 0.05)
                        No change in performance detected.
Benchmarking parameterized reconstruct validator_count=36/novel-poly-reconstruct/4445000: Collecting 10 samples in estimated 6                                                                                                                              parameterized reconstruct validator_count=36/novel-poly-reconstruct/4445000                        
                        time:   [313.63 ms 316.13 ms 318.63 ms]
                        change: [-1.0543% +0.3799% +1.8239%] (p = 0.63 > 0.05)
                        No change in performance detected.
Benchmarking parameterized reconstruct validator_count=36/novel-poly-reconstruct/5556000: Collecting 10 samples in estimated 7                                                                                                                              parameterized reconstruct validator_count=36/novel-poly-reconstruct/5556000                        
                        time:   [385.38 ms 387.41 ms 389.46 ms]
                        change: [-0.8567% -0.1112% +0.6436%] (p = 0.79 > 0.05)
                        No change in performance detected.
Benchmarking parameterized reconstruct validator_count=36/novel-poly-reconstruct/6667000: Collecting 10 samples in estimated 9                                                                                                                              parameterized reconstruct validator_count=36/novel-poly-reconstruct/6667000                        
                        time:   [465.21 ms 472.38 ms 479.11 ms]
                        change: [-1.3777% +0.7692% +2.9817%] (p = 0.51 > 0.05)
                        No change in performance detected.
Benchmarking parameterized reconstruct validator_count=36/novel-poly-reconstruct/7778000: Warming up for 100.00 ms
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 5.3s.
Benchmarking parameterized reconstruct validator_count=36/novel-poly-reconstruct/7778000: Collecting 10 samples in estimated 5                                                                                                                              parameterized reconstruct validator_count=36/novel-poly-reconstruct/7778000                        
                        time:   [546.39 ms 555.86 ms 563.86 ms]
                        change: [-0.0845% +1.8509% +3.7129%] (p = 0.08 > 0.05)
                        No change in performance detected.
Benchmarking parameterized reconstruct validator_count=36/novel-poly-reconstruct/8889000: Warming up for 100.00 ms
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 6.7s.
Benchmarking parameterized reconstruct validator_count=36/novel-poly-reconstruct/8889000: Collecting 10 samples in estimated 6                                                                                                                              parameterized reconstruct validator_count=36/novel-poly-reconstruct/8889000                        
                        time:   [637.63 ms 640.95 ms 643.33 ms]
                        change: [+1.9814% +2.8450% +3.7888%] (p = 0.00 < 0.05)
                        Performance has regressed.

Benchmarking parameterized reconstruct validator_count=68/novel-poly-reconstruct/1000: Collecting 10 samples in estimated 5.01                                                                                                                              parameterized reconstruct validator_count=68/novel-poly-reconstruct/1000                        
                        time:   [857.43 µs 864.19 µs 871.75 µs]
                        change: [-2.9070% -1.5187% +0.0505%] (p = 0.06 > 0.05)
                        No change in performance detected.
Benchmarking parameterized reconstruct validator_count=68/novel-poly-reconstruct/1112000: Collecting 10 samples in estimated 9                                                                                                                              parameterized reconstruct validator_count=68/novel-poly-reconstruct/1112000                        
                        time:   [85.425 ms 85.583 ms 85.658 ms]
                        change: [+1.2534% +2.2184% +3.1313%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking parameterized reconstruct validator_count=68/novel-poly-reconstruct/2223000: Warming up for 100.00 ms
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 9.4s or enable flat sampling.
Benchmarking parameterized reconstruct validator_count=68/novel-poly-reconstruct/2223000: Collecting 10 samples in estimated 9                                                                                                                              parameterized reconstruct validator_count=68/novel-poly-reconstruct/2223000                        
                        time:   [162.13 ms 164.96 ms 168.54 ms]
                        change: [-1.8324% -0.6450% +0.3839%] (p = 0.33 > 0.05)
                        No change in performance detected.
Benchmarking parameterized reconstruct validator_count=68/novel-poly-reconstruct/3334000: Collecting 10 samples in estimated 5                                                                                                                              parameterized reconstruct validator_count=68/novel-poly-reconstruct/3334000                        
                        time:   [241.64 ms 245.60 ms 249.91 ms]
                        change: [-1.0837% +0.7288% +2.7102%] (p = 0.47 > 0.05)
                        No change in performance detected.
Benchmarking parameterized reconstruct validator_count=68/novel-poly-reconstruct/4445000: Collecting 10 samples in estimated 6                                                                                                                              parameterized reconstruct validator_count=68/novel-poly-reconstruct/4445000                        
                        time:   [330.50 ms 331.23 ms 331.87 ms]
                        change: [+0.6245% +1.1306% +1.7007%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Benchmarking parameterized reconstruct validator_count=68/novel-poly-reconstruct/5556000: Collecting 10 samples in estimated 8                                                                                                                              parameterized reconstruct validator_count=68/novel-poly-reconstruct/5556000                        
                        time:   [405.54 ms 412.76 ms 420.21 ms]
                        change: [-0.5005% +1.2816% +3.2591%] (p = 0.24 > 0.05)
                        No change in performance detected.
Benchmarking parameterized reconstruct validator_count=68/novel-poly-reconstruct/6667000: Warming up for 100.00 ms
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 5.2s.
Benchmarking parameterized reconstruct validator_count=68/novel-poly-reconstruct/6667000: Collecting 10 samples in estimated 5                                                                                                                              parameterized reconstruct validator_count=68/novel-poly-reconstruct/6667000                        
                        time:   [510.12 ms 513.50 ms 516.66 ms]
                        change: [+1.5013% +2.5678% +3.6595%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking parameterized reconstruct validator_count=68/novel-poly-reconstruct/7778000: Warming up for 100.00 ms
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 6.0s.
Benchmarking parameterized reconstruct validator_count=68/novel-poly-reconstruct/7778000: Collecting 10 samples in estimated 5                                                                                                                              parameterized reconstruct validator_count=68/novel-poly-reconstruct/7778000                        
                        time:   [568.65 ms 574.79 ms 581.92 ms]
                        change: [-1.2400% +0.0279% +1.4927%] (p = 0.97 > 0.05)
                        No change in performance detected.
Benchmarking parameterized reconstruct validator_count=68/novel-poly-reconstruct/8889000: Warming up for 100.00 ms
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 6.7s.
Benchmarking parameterized reconstruct validator_count=68/novel-poly-reconstruct/8889000: Collecting 10 samples in estimated 6                                                                                                                              parameterized reconstruct validator_count=68/novel-poly-reconstruct/8889000                        
                        time:   [650.95 ms 656.56 ms 661.59 ms]
                        change: [-0.2698% +0.6998% +1.6641%] (p = 0.20 > 0.05)
                        No change in performance detected.

Benchmarking parameterized encode fixed payload/novel-poly-encode/4: Collecting 10 samples in estimated 5.2719 s (275 iteratio                                                                                                                              parameterized encode fixed payload/novel-poly-encode/4                        
                        time:   [17.014 ms 17.030 ms 17.046 ms]
                        change: [-0.7759% -0.6211% -0.4414%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Benchmarking parameterized encode fixed payload/novel-poly-encode/70: Collecting 10 samples in estimated 5.5904 s (110 iterati                                                                                                                              parameterized encode fixed payload/novel-poly-encode/70                        
                        time:   [43.630 ms 43.741 ms 44.033 ms]
                        change: [+3.4299% +6.0086% +9.6182%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking parameterized encode fixed payload/novel-poly-encode/136: Collecting 10 samples in estimated 5.3723 s (110 iterat                                                                                                                              parameterized encode fixed payload/novel-poly-encode/136                        
                        time:   [42.874 ms 42.976 ms 43.074 ms]
                        change: [+4.7800% +5.0857% +5.3466%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking parameterized encode fixed payload/novel-poly-encode/202: Collecting 10 samples in estimated 5.8206 s (220 iterat                                                                                                                              parameterized encode fixed payload/novel-poly-encode/202                        
                        time:   [24.325 ms 24.359 ms 24.404 ms]
                        change: [+2.4648% +3.1764% +3.9185%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking parameterized encode fixed payload/novel-poly-encode/268: Collecting 10 samples in estimated 6.1405 s (110 iterat                                                                                                                              parameterized encode fixed payload/novel-poly-encode/268                        
                        time:   [47.346 ms 47.558 ms 47.690 ms]
                        change: [+1.8391% +2.2574% +2.7154%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking parameterized encode fixed payload/novel-poly-encode/334: Collecting 10 samples in estimated 5.9116 s (110 iterat                                                                                                                              parameterized encode fixed payload/novel-poly-encode/334                        
                        time:   [48.421 ms 48.599 ms 48.772 ms]
                        change: [+7.2664% +7.8907% +8.5212%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking parameterized encode fixed payload/novel-poly-encode/400: Collecting 10 samples in estimated 5.5265 s (165 iterat                                                                                                                              parameterized encode fixed payload/novel-poly-encode/400                        
                        time:   [24.573 ms 24.634 ms 24.729 ms]
                        change: [+0.7166% +1.8292% +2.7818%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Benchmarking parameterized encode fixed payload/novel-poly-encode/466: Collecting 10 samples in estimated 6.1715 s (220 iterat                                                                                                                              parameterized encode fixed payload/novel-poly-encode/466                        
                        time:   [25.799 ms 25.842 ms 25.895 ms]
                        change: [+1.7627% +2.0307% +2.2670%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking parameterized encode fixed payload/novel-poly-encode/532: Collecting 10 samples in estimated 6.3705 s (110 iterat                                                                                                                              parameterized encode fixed payload/novel-poly-encode/532                        
                        time:   [49.348 ms 49.439 ms 49.515 ms]
                        change: [+3.2120% +3.4550% +3.6709%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking parameterized encode fixed payload/novel-poly-encode/598: Collecting 10 samples in estimated 6.3244 s (110 iterat                                                                                                                              parameterized encode fixed payload/novel-poly-encode/598                        
                        time:   [48.825 ms 48.961 ms 49.060 ms]
                        change: [+0.2173% +0.4212% +0.6317%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Benchmarking parameterized encode fixed payload/novel-poly-encode/664: Collecting 10 samples in estimated 6.1971 s (110 iterat                                                                                                                              parameterized encode fixed payload/novel-poly-encode/664                        
                        time:   [49.571 ms 49.782 ms 49.998 ms]
                        change: [+0.0496% +0.4323% +0.8660%] (p = 0.06 > 0.05)
                        No change in performance detected.
Benchmarking parameterized encode fixed payload/novel-poly-encode/730: Collecting 10 samples in estimated 6.2679 s (110 iterat                                                                                                                              parameterized encode fixed payload/novel-poly-encode/730                        
                        time:   [51.846 ms 51.914 ms 51.962 ms]
                        change: [+2.9079% +3.2654% +3.5350%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking parameterized encode fixed payload/novel-poly-encode/796: Collecting 10 samples in estimated 5.9868 s (165 iterat                                                                                                                              parameterized encode fixed payload/novel-poly-encode/796                        
                        time:   [27.732 ms 27.843 ms 27.957 ms]
                        change: [+3.7564% +4.1554% +4.6107%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking parameterized encode fixed payload/novel-poly-encode/862: Collecting 10 samples in estimated 6.5991 s (220 iterat                                                                                                                              parameterized encode fixed payload/novel-poly-encode/862                        
                        time:   [27.414 ms 27.488 ms 27.557 ms]
                        change: [+0.6770% +1.1796% +1.7097%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Benchmarking parameterized encode fixed payload/novel-poly-encode/928: Collecting 10 samples in estimated 5.5208 s (165 iterat                                                                                                                              parameterized encode fixed payload/novel-poly-encode/928                        
                        time:   [27.541 ms 27.812 ms 28.024 ms]
                        change: [+0.5307% +1.2063% +1.8771%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Benchmarking parameterized encode fixed payload/novel-poly-encode/994: Collecting 10 samples in estimated 6.1139 s (220 iterat                                                                                                                              parameterized encode fixed payload/novel-poly-encode/994                        
                        time:   [28.048 ms 28.516 ms 28.915 ms]
                        change: [+0.6676% +1.8381% +3.1353%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking parameterized reconstruct fixed payload/novel-poly-reconstruct/4: Collecting 10 samples in estimated 5.0012 s (14                                                                                                                              parameterized reconstruct fixed payload/novel-poly-reconstruct/4                        
                        time:   [33.156 µs 33.355 µs 33.676 µs]
                        change: [-6.2387% -4.6504% -3.1204%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking parameterized reconstruct fixed payload/novel-poly-reconstruct/70: Collecting 10 samples in estimated 8.4051 s (1                                                                                                                              parameterized reconstruct fixed payload/novel-poly-reconstruct/70                        
                        time:   [72.185 ms 72.341 ms 72.698 ms]
                        change: [-18.122% -17.062% -15.934%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking parameterized reconstruct fixed payload/novel-poly-reconstruct/136: Collecting 10 samples in estimated 8.5586 s (                                                                                                                              parameterized reconstruct fixed payload/novel-poly-reconstruct/136                        
                        time:   [77.096 ms 77.372 ms 77.903 ms]
                        change: [-2.0825% -0.3062% +1.6248%] (p = 0.75 > 0.05)
                        No change in performance detected.
Benchmarking parameterized reconstruct fixed payload/novel-poly-reconstruct/202: Collecting 10 samples in estimated 6.8974 s (                                                                                                                              parameterized reconstruct fixed payload/novel-poly-reconstruct/202                        
                        time:   [41.785 ms 42.102 ms 42.461 ms]
                        change: [-1.8074% -0.4531% +0.8970%] (p = 0.55 > 0.05)
                        No change in performance detected.
Benchmarking parameterized reconstruct fixed payload/novel-poly-reconstruct/268: Collecting 10 samples in estimated 9.8923 s (                                                                                                                              parameterized reconstruct fixed payload/novel-poly-reconstruct/268                        
                        time:   [82.805 ms 83.605 ms 84.788 ms]
                        change: [-0.7433% +0.8343% +2.6662%] (p = 0.34 > 0.05)
                        No change in performance detected.
Benchmarking parameterized reconstruct fixed payload/novel-poly-reconstruct/334: Collecting 10 samples in estimated 9.8431 s (                                                                                                                              parameterized reconstruct fixed payload/novel-poly-reconstruct/334                        
                        time:   [88.214 ms 88.455 ms 88.795 ms]
                        change: [-0.6356% +0.9374% +2.5961%] (p = 0.29 > 0.05)
                        No change in performance detected.
Benchmarking parameterized reconstruct fixed payload/novel-poly-reconstruct/400: Collecting 10 samples in estimated 5.1090 s (                                                                                                                              parameterized reconstruct fixed payload/novel-poly-reconstruct/400                        
                        time:   [46.138 ms 46.437 ms 46.830 ms]
                        change: [-1.1516% +0.4679% +2.0814%] (p = 0.60 > 0.05)
                        No change in performance detected.
Benchmarking parameterized reconstruct fixed payload/novel-poly-reconstruct/466: Collecting 10 samples in estimated 7.4548 s (                                                                                                                              parameterized reconstruct fixed payload/novel-poly-reconstruct/466                        
                        time:   [45.338 ms 45.464 ms 45.607 ms]
                        change: [-5.6881% -3.7581% -1.8554%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking parameterized reconstruct fixed payload/novel-poly-reconstruct/532: Collecting 10 samples in estimated 9.5667 s (                                                                                                                              parameterized reconstruct fixed payload/novel-poly-reconstruct/532                        
                        time:   [87.509 ms 87.867 ms 88.252 ms]
                        change: [-5.6407% -4.7980% -3.8126%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking parameterized reconstruct fixed payload/novel-poly-reconstruct/598: Warming up for 100.00 ms
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 5.2s or enable flat sampling.
parameterized reconstruct fixed payload/novel-poly-reconstruct/598                                                                          
                        time:   [93.638 ms 93.805 ms 94.057 ms]
                        change: [+1.0113% +2.0420% +3.0251%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking parameterized reconstruct fixed payload/novel-poly-reconstruct/664: Warming up for 100.00 ms
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 5.2s or enable flat sampling.
parameterized reconstruct fixed payload/novel-poly-reconstruct/664                                                                          
                        time:   [94.666 ms 95.346 ms 96.151 ms]
                        change: [+0.1129% +1.9582% +4.1042%] (p = 0.08 > 0.05)
                        No change in performance detected.
Benchmarking parameterized reconstruct fixed payload/novel-poly-reconstruct/730: Warming up for 100.00 ms
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 5.3s or enable flat sampling.
parameterized reconstruct fixed payload/novel-poly-reconstruct/730                                                                          
                        time:   [90.105 ms 90.311 ms 90.722 ms]
                        change: [-4.4338% -2.3209% +0.1337%] (p = 0.09 > 0.05)
                        No change in performance detected.
parameterized reconstruct fixed payload/novel-poly-reconstruct/796                                                                           
                        time:   [50.469 ms 50.917 ms 51.237 ms]
                        change: [+4.4306% +5.3772% +6.4495%] (p = 0.00 < 0.05)
                        Performance has regressed.
parameterized reconstruct fixed payload/novel-poly-reconstruct/862                                                                           
                        time:   [50.287 ms 50.489 ms 50.747 ms]
                        change: [+3.1639% +4.4400% +6.3080%] (p = 0.00 < 0.05)
                        Performance has regressed.
parameterized reconstruct fixed payload/novel-poly-reconstruct/928                                                                           
                        time:   [47.991 ms 48.088 ms 48.180 ms]
                        change: [-3.5466% -3.0325% -2.5615%] (p = 0.00 < 0.05)
                        Performance has improved.
parameterized reconstruct fixed payload/novel-poly-reconstruct/994                                                                           
                        time:   [49.589 ms 49.699 ms 49.799 ms]
                        change: [+1.9317% +2.3540% +2.7583%] (p = 0.00 < 0.05)
                        Performance has regressed.
```