### PR TITLE
small encoding allocation optimisation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.DS_Store

--- a/reed-solomon-novelpoly/src/field/inc_encode.rs
+++ b/reed-solomon-novelpoly/src/field/inc_encode.rs
@@ -200,13 +200,11 @@ pub fn encode_sub_plain(bytes: &[u8], n: usize, k: usize) -> Result<Vec<Additive
 	// pad the incoming bytes with trailing 0s
 	// so we get a buffer of size `N` in `GF` symbols
 	let zero_bytes_to_add = n * 2 - bytes_len;
-	let elm_data = Vec::<Additive>::from_iter(bytes
-		.iter()
-		.copied()
-		.chain(std::iter::repeat(0u8).take(zero_bytes_to_add))
-		.tuple_windows()
-		.step_by(2)
-		.map(|(a, b)| Additive(Elt::from_be_bytes([a, b]))));
+	let mut elm_data = Vec::with_capacity(zero_bytes_to_add + (bytes.len() / 2));
+	let zeros = std::iter::repeat(&0u8).take(zero_bytes_to_add);
+	for (first, second) in bytes.into_iter().chain(zeros).tuples() {
+		elm_data.push(Additive(Elt::from_be_bytes([*first, *second])));
+	}
 
 	// update new data bytes with zero padded bytes
 	// `l` is now `GF(2^16)` symbols


### PR DESCRIPTION
Profiling with dtrace showed that the current code is doing quite a lot of reallocations, coming from the `from_iter` call.

This PR brings a ~10-20% performance improvement for the encoding part, in terms of total duration.

Benchmarked this change with kagome's benchmark.

`num_validators = 100`

Previously, on my M2 Pro with 32 Gib RAM, results were: 
```
~~~ [ Benchmark case: 303 bytes ] ~~~
Encode RUST (100 cycles): 846 us
Decode RUST (100 cycles): 55.689 ms
Encode C++ (100 cycles): 519 us
Decode C++ (100 cycles): 30.949 ms

~~~ [ Benchmark case: 5007 bytes ] ~~~
Encode RUST (100 cycles): 11.092 ms
Decode RUST (100 cycles): 73.303 ms
Encode C++ (100 cycles): 5.334 ms
Decode C++ (100 cycles): 42.614 ms

~~~ [ Benchmark case: 100015 bytes ] ~~~
Encode RUST (100 cycles): 215.752 ms
Decode RUST (100 cycles): 428.894 ms
Encode C++ (100 cycles): 100.325 ms
Decode C++ (100 cycles): 280.875 ms

~~~ [ Benchmark case: 1000015 bytes ] ~~~
Encode RUST (100 cycles): 2154.09 ms
Decode RUST (100 cycles): 3880.8 ms
Encode C++ (100 cycles): 1001.65 ms
Decode C++ (100 cycles): 2552.96 ms

~~~ [ Benchmark case: 10000015 bytes ] ~~~
Encode RUST (100 cycles): 29.2552 s
Decode RUST (100 cycles): 39.0674 s
Encode C++ (100 cycles): 15.8985 s
Decode C++ (100 cycles): 26.2342 s
```

With this PR, results are:
```
~~~ [ Benchmark case: 303 bytes ] ~~~
Encode RUST (100 cycles): 748 us
Decode RUST (100 cycles): 56.005 ms
Encode C++ (100 cycles): 530 us
Decode C++ (100 cycles): 30.887 ms

~~~ [ Benchmark case: 5007 bytes ] ~~~
Encode RUST (100 cycles): 8.986 ms
Decode RUST (100 cycles): 73.672 ms
Encode C++ (100 cycles): 5.406 ms
Decode C++ (100 cycles): 42.62 ms

~~~ [ Benchmark case: 100015 bytes ] ~~~
Encode RUST (100 cycles): 172.488 ms
Decode RUST (100 cycles): 429.697 ms
Encode C++ (100 cycles): 99.037 ms
Decode C++ (100 cycles): 279.038 ms

~~~ [ Benchmark case: 1000015 bytes ] ~~~
Encode RUST (100 cycles): 1723.59 ms
Decode RUST (100 cycles): 3842.43 ms
Encode C++ (100 cycles): 1008.16 ms
Decode C++ (100 cycles): 2571.68 ms

~~~ [ Benchmark case: 10000015 bytes ] ~~~
Encode RUST (100 cycles): 25.0707 s
Decode RUST (100 cycles): 39.4162 s
Encode C++ (100 cycles): 16.0018 s
Decode C++ (100 cycles): 26.1704 s
```