### PR TITLE
implement #24 for simd code path

### DIFF
--- a/reed-solomon-novelpoly/src/field/inc_encode.rs
+++ b/reed-solomon-novelpoly/src/field/inc_encode.rs
@@ -243,21 +243,17 @@ pub fn encode_sub_faster8(bytes: &[u8], n: usize, k: usize) -> Result<Vec<Additi
 	assert!(is_power_of_2(upper_len));
 	assert!(upper_len >= bytes_len);
 
-    // tuple_windows are only used here
+    // tuples are only used here
     use itertools::Itertools;
 
 	// pad the incoming bytes with trailing 0s
 	// so we get a buffer of size `N` in `GF` symbols
 	let zero_bytes_to_add = n * 2 - bytes_len;
-	let elm_data = Vec::<Additive>::from_iter(
-		bytes
-		.iter()
-		.copied()
-		.chain(std::iter::repeat(0u8).take(zero_bytes_to_add))
-		.tuple_windows()
-		.step_by(2)
-		.map(|(a,b)| Additive(Elt::from_be_bytes([a, b])))
-	);
+	let mut elm_data = Vec::with_capacity(n);
+	let zeros = std::iter::repeat(&0u8).take(zero_bytes_to_add);
+	for (first, second) in bytes.iter().chain(zeros).tuples() {
+		elm_data.push(Additive(Elt::from_be_bytes([*first, *second])));
+	}
 
 	// update new data bytes with zero padded bytes
 	// `l` is now `GF(2^16)` symbols


### PR DESCRIPTION
Port of https://github.com/paritytech/reed-solomon-novelpoly/pull/24 for avx code.
speeds up encoding procedure with avx enabled by around 10%.