### PR TITLE
optimise some of the bounds checks

### DIFF
--- a/reed-solomon-novelpoly/src/field/inc_afft.rs
+++ b/reed-solomon-novelpoly/src/field/inc_afft.rs
@@ -89,7 +89,8 @@ fn b_is_one() {
 
 /// Inverse additive FFT in the "novel polynomial basis"
 ///
-/// # Safety: See safety section of `AdditiveFFT::inverse_afft`.
+/// # Safety
+/// See safety section of `AdditiveFFT::inverse_afft`.
 pub unsafe fn inverse_afft(data: &mut [Additive], size: usize, index: usize) {
 	unsafe { &AFFT }.inverse_afft(data, size, index)
 }
@@ -101,7 +102,8 @@ pub fn inverse_afft_faster8(data: &mut [Additive], size: usize, index: usize) {
 
 /// Additive FFT in the "novel polynomial basis"
 ///
-/// # Safety: See safety section of `AdditiveFFT::afft`.
+/// # Safety
+/// See safety section of `AdditiveFFT::afft`.
 pub unsafe fn afft(data: &mut [Additive], size: usize, index: usize) {
 	unsafe { &AFFT }.afft(data, size, index)
 }
@@ -597,7 +599,9 @@ mod afft_tests {
 			let mut data_plain = gen_plain::<SmallRng>(size);
 			let mut data_faster8 = gen_faster8::<SmallRng>(size);
 			println!(">>>>");
-			unsafe { &AFFT }.afft(&mut data_plain, size, index);
+			unsafe {
+				AFFT.afft(&mut data_plain, size, index);
+			}
 			println!(
 				r#"
 
@@ -618,7 +622,9 @@ mod afft_tests {
 			let mut data_plain = gen_plain::<SmallRng>(size);
 			let mut data_faster8 = gen_faster8::<SmallRng>(size);
 			println!(">>>>");
-			unsafe { &AFFT }.afft(&mut data_plain, size, index);
+			unsafe {
+				AFFT.afft(&mut data_plain, size, index);
+			}
 			println!(
 				r#"
 
@@ -627,6 +633,7 @@ mod afft_tests {
 			"#
 			);
 			unsafe { &AFFT }.afft_faster8(&mut data_faster8, size, index);
+
 			println!(">>>>");
 			assert_plain_eq_faster8(data_plain, data_faster8);
 		}
@@ -644,7 +651,9 @@ mod afft_tests {
 			assert_plain_eq_faster8(&data_plain, &data_faster8);
 
 			println!(">>>>");
-			unsafe { &AFFT }.afft(&mut data_plain, size, index);
+			unsafe {
+				AFFT.afft(&mut data_plain, size, index);
+			}
 			println!(
 				r#"
 
@@ -667,7 +676,9 @@ mod afft_tests {
 			assert_plain_eq_faster8(&data_plain, &data_faster8);
 
 			println!(">>>>");
-			unsafe { &AFFT }.inverse_afft(&mut data_plain, size, index);
+			unsafe {
+				AFFT.inverse_afft(&mut data_plain, size, index);
+			}
 			println!(
 				r#"
 
@@ -688,7 +699,9 @@ mod afft_tests {
 			let mut data_plain = gen_plain::<SmallRng>(size);
 			let mut data_faster8 = gen_faster8::<SmallRng>(size);
 			println!(">>>>");
-			unsafe { &AFFT }.inverse_afft(&mut data_plain, size, index);
+			unsafe {
+				AFFT.inverse_afft(&mut data_plain, size, index);
+			}
 			println!(
 				r#"
 

--- a/reed-solomon-novelpoly/src/field/inc_afft.rs
+++ b/reed-solomon-novelpoly/src/field/inc_afft.rs
@@ -523,9 +523,7 @@ mod afft_tests {
 			let mut data_plain = gen_plain::<SmallRng>(size);
 			let mut data_faster8 = gen_faster8::<SmallRng>(size);
 			println!(">>>>");
-			unsafe {
-				AFFT.afft(&mut data_plain, size, index);
-			}
+			unsafe { &AFFT }.afft(&mut data_plain, size, index);
 			println!(
 				r#"
 
@@ -546,9 +544,7 @@ mod afft_tests {
 			let mut data_plain = gen_plain::<SmallRng>(size);
 			let mut data_faster8 = gen_faster8::<SmallRng>(size);
 			println!(">>>>");
-			unsafe {
-				AFFT.afft(&mut data_plain, size, index);
-			}
+			unsafe { &AFFT }.afft(&mut data_plain, size, index);
 			println!(
 				r#"
 
@@ -557,7 +553,6 @@ mod afft_tests {
 			"#
 			);
 			unsafe { &AFFT }.afft_faster8(&mut data_faster8, size, index);
-
 			println!(">>>>");
 			assert_plain_eq_faster8(data_plain, data_faster8);
 		}
@@ -575,9 +570,7 @@ mod afft_tests {
 			assert_plain_eq_faster8(&data_plain, &data_faster8);
 
 			println!(">>>>");
-			unsafe {
-				AFFT.afft(&mut data_plain, size, index);
-			}
+			unsafe { &AFFT }.afft(&mut data_plain, size, index);
 			println!(
 				r#"
 
@@ -600,9 +593,7 @@ mod afft_tests {
 			assert_plain_eq_faster8(&data_plain, &data_faster8);
 
 			println!(">>>>");
-			unsafe {
-				AFFT.inverse_afft(&mut data_plain, size, index);
-			}
+			unsafe { &AFFT }.inverse_afft(&mut data_plain, size, index);
 			println!(
 				r#"
 
@@ -623,9 +614,7 @@ mod afft_tests {
 			let mut data_plain = gen_plain::<SmallRng>(size);
 			let mut data_faster8 = gen_faster8::<SmallRng>(size);
 			println!(">>>>");
-			unsafe {
-				AFFT.inverse_afft(&mut data_plain, size, index);
-			}
+			unsafe { &AFFT }.inverse_afft(&mut data_plain, size, index);
 			println!(
 				r#"
 

--- a/reed-solomon-novelpoly/src/field/inc_encode.rs
+++ b/reed-solomon-novelpoly/src/field/inc_encode.rs
@@ -7,7 +7,7 @@ pub fn encode_low(data: &[Additive], k: usize, codeword: &mut [Additive], n: usi
 		encode_low_plain(data, k, codeword, n);
 	}
 
-	#[cfg(not(target_feature = "avx"))]
+	#[cfg(not(all(target_feature = "avx", feature = "avx")))]
 	encode_low_plain(data, k, codeword, n);
 }
 
@@ -188,7 +188,7 @@ pub fn encode_sub(bytes: &[u8], n: usize, k: usize) -> Result<Vec<Additive>> {
 	} else {
 		encode_sub_plain(bytes, n, k)
 	}
-	#[cfg(not(target_feature = "avx"))]
+	#[cfg(not(all(target_feature = "avx", feature = "avx")))]
 	encode_sub_plain(bytes, n, k)
 }
 

--- a/reed-solomon-novelpoly/src/field/inc_encode.rs
+++ b/reed-solomon-novelpoly/src/field/inc_encode.rs
@@ -29,20 +29,36 @@ pub fn encode_low_plain(data: &[Additive], k: usize, codeword: &mut [Additive], 
 	// split after the first k
 	let (codeword_first_k, codeword_skip_first_k) = codeword.split_at_mut(k);
 
-	inverse_afft(codeword_first_k, k, 0);
+	// - safe because codeword_first_k is exactly k elements and k is a power of two.
+	// - safe because `index + size - 2` is `k - 2`. k is at most n/2 and n is at most 65536. Therefore,
+	// k is at most 65536/2-2 = 32766 (smaller than 65535). qed.
+	unsafe { inverse_afft(codeword_first_k, k, 0) };
 
 	// dbg!(&codeword_first_k);
 	// the first codeword is now the basis for the remaining transforms
 	// denoted `M_topdash`
 
 	for shift in (k..n).step_by(k) {
+		#[cfg(debug)]
 		let codeword_at_shift = &mut codeword_skip_first_k[(shift - k)..shift];
+
+		#[cfg(not(debug))]
+		// SAFETY
+		//
+		// n is i*k, with i at least 2. shift is at most (i-1)*k.
+		// (i-1) * k will always be smaller than i*k for all i greater than 2.
+		// Similarly, shift - k will always be smaller than shift, since they're positive integers
+		// and shift is at least equal to k.
+		let codeword_at_shift = unsafe { codeword_skip_first_k.get_unchecked_mut((shift - k)..shift) };
+
 		// copy `M_topdash` to the position we are currently at, the n transform
 		codeword_at_shift.copy_from_slice(codeword_first_k);
-		// dbg!(&codeword_at_shift);
-		afft(codeword_at_shift, k, shift);
-		// let post = &codeword_at_shift;
-		// dbg!(post);
+		// SAFETY
+		//
+		// - safe because codeword_first_k is exactly k elements and k is a power of two.
+		// - k is at most n/2 (32768). `index + size - 2` is therefore equal to 2*k - 2 = 65534 which
+		// is less than or equal to 65534. qed.
+		unsafe { afft(codeword_at_shift, k, shift) };
 	}
 
 	// restore `M` from the derived ones
@@ -78,12 +94,21 @@ pub fn encode_low_faster8(data: &[Additive], k: usize, codeword: &mut [Additive]
 	// denoted `M_topdash`
 
 	for shift in (k..n).step_by(k) {
+		#[cfg(debug)]
 		let codeword_at_shift = &mut codeword_skip_first_k[(shift - k)..shift];
+
+		#[cfg(not(debug))]
+		// SAFETY
+		//
+		// n is i*k, with i at least 2. shift is at most (i-1)*k.
+		// (i-1) * k will always be smaller than i*k for all i greater than 2.
+		// Similarly, shift - k will always be smaller than shift, since they're positive integers
+		// and shift is at least equal to k.
+		let codeword_at_shift = unsafe { codeword_skip_first_k.get_unchecked_mut((shift - k)..shift) };
+
 		// copy `M_topdash` to the position we are currently at, the n transform
 		codeword_at_shift.copy_from_slice(codeword_first_k);
-
 		afft_faster8(codeword_at_shift, k, shift);
-		// let post = &codeword8x_at_shift;
 	}
 
 	// restore `M` from the derived ones
@@ -93,63 +118,68 @@ pub fn encode_low_faster8(data: &[Additive], k: usize, codeword: &mut [Additive]
 
 //data: message array. parity: parity array. mem: buffer(size>= n-k)
 //Encoding alg for k/n>0.5: parity is a power of two.
-#[inline(always)]
-pub fn encode_high(data: &[Additive], k: usize, parity: &mut [Additive], mem: &mut [Additive], n: usize) {
-	#[cfg(all(target_feature = "avx", feature = "avx"))]
-	if (n - k) % Additive8x::LANE == 0 && n % Additive8x::LANE == 0 && k % Additive8x::LANE == 0 {
-		encode_high_faster8(data, k, parity, mem, n);
-	} else {
-		encode_high_plain(data, k, parity, mem, n);
-	}
-	#[cfg(not(target_feature = "avx"))]
-	encode_high_plain(data, k, parity, mem, n);
-}
+// Function is not exposed/tested. Consider the safety guidelines of the *afft functions before using.
+// #[inline(always)]
+// pub fn encode_high(data: &[Additive], k: usize, parity: &mut [Additive], mem: &mut [Additive], n: usize) {
+// 	#[cfg(all(target_feature = "avx", feature = "avx"))]
+// 	if (n - k) % Additive8x::LANE == 0 && n % Additive8x::LANE == 0 && k % Additive8x::LANE == 0 {
+// 		encode_high_faster8(data, k, parity, mem, n);
+// 	} else {
+// 		encode_high_plain(data, k, parity, mem, n);
+// 	}
+// 	#[cfg(not(target_feature = "avx"))]
+// 	encode_high_plain(data, k, parity, mem, n);
+// }
 
 //data: message array. parity: parity array. mem: buffer(size>= n-k)
 //Encoding alg for k/n>0.5: parity is a power of two.
-pub fn encode_high_plain(data: &[Additive], k: usize, parity: &mut [Additive], mem: &mut [Additive], n: usize) {
-	let t: usize = n - k;
+// Function is not exposed/tested. Consider the safety guidelines of the *afft functions before using.
+// pub fn encode_high_plain(data: &[Additive], k: usize, parity: &mut [Additive], mem: &mut [Additive], n: usize) {
+// 	assert!(is_power_of_2(n));
 
-	// mem_zero(&mut parity[0..t]);
-	for i in 0..t {
-		parity[i] = Additive(0);
-	}
+// 	let t: usize = n - k;
 
-	let mut i = t;
-	while i < n {
-		mem[..t].copy_from_slice(&data[(i - t)..t]);
+// 	// mem_zero(&mut parity[0..t]);
+// 	for i in 0..t {
+// 		parity[i] = Additive(0);
+// 	}
 
-		inverse_afft(mem, t, i);
-		for j in 0..t {
-			parity[j] ^= mem[j];
-		}
-		i += t;
-	}
-	afft(parity, t, 0);
-}
+// 	let mut i = t;
+// 	while i < n {
+// 		mem[..t].copy_from_slice(&data[(i - t)..t]);
 
-#[cfg(all(target_feature = "avx", feature = "avx"))]
-pub fn encode_high_faster8(data: &[Additive], k: usize, parity: &mut [Additive], mem: &mut [Additive], n: usize) {
-	let t: usize = n - k;
-	assert!(t >= 8);
-	assert_eq!(t % 8, 0);
+// 		unsafe { inverse_afft(mem, t, i) };
+// 		for j in 0..t {
+// 			parity[j] ^= mem[j];
+// 		}
+// 		i += t;
+// 	}
+// 	unsafe { afft(parity, t, 0) };
+// }
 
-	for i in 0..t {
-		parity[i] = Additive::zero();
-	}
+// #[cfg(all(target_feature = "avx", feature = "avx"))]
+// Function is not exposed/tested. Consider the safety guidelines of the *afft functions before using.
+// pub fn encode_high_faster8(data: &[Additive], k: usize, parity: &mut [Additive], mem: &mut [Additive], n: usize) {
+// 	let t: usize = n - k;
+// 	assert!(t >= 8);
+// 	assert_eq!(t % 8, 0);
 
-	let mut i = t;
-	while i < n {
-		mem[..t].copy_from_slice(&data[(i - t)..t]);
+// 	for i in 0..t {
+// 		parity[i] = Additive::zero();
+// 	}
 
-		inverse_afft_faster8(mem, t, i);
-		for j in 0..t {
-			parity[j] ^= mem[j];
-		}
-		i += t;
-	}
-	afft_faster8(parity, t, 0);
-}
+// 	let mut i = t;
+// 	while i < n {
+// 		mem[..t].copy_from_slice(&data[(i - t)..t]);
+
+// 		inverse_afft_faster8(mem, t, i);
+// 		for j in 0..t {
+// 			parity[j] ^= mem[j];
+// 		}
+// 		i += t;
+// 	}
+// 	afft_faster8(parity, t, 0);
+// }
 
 pub fn encode_sub(bytes: &[u8], n: usize, k: usize) -> Result<Vec<Additive>> {
 	#[cfg(all(target_feature = "avx", feature = "avx"))]
@@ -191,10 +221,26 @@ pub fn encode_sub_plain(bytes: &[u8], n: usize, k: usize) -> Result<Vec<Additive
 	let mut elm_data = vec![Additive(0); n];
 
 	for i in 0..(bytes_len / 2) {
-		elm_data[i] = Additive(Elt::from_be_bytes([
-			bytes.get(2 * i).copied().unwrap_or_default(),
-			bytes.get(2 * i + 1).copied().unwrap_or_default(),
-		]))
+		#[cfg(debug)]
+		{
+			elm_data[i] = Additive(Elt::from_be_bytes([
+				bytes.get(2 * i).copied().unwrap_or_default(),
+				bytes.get(2 * i + 1).copied().unwrap_or_default(),
+			]));
+		}
+		#[cfg(not(debug))]
+		{
+			// SAFETY
+			//
+			// i is used to index `elm_data`, which is preallocated to n elements.
+			// i goes from 0 (bytes.len() / 2) and we assert that bytes.len() <= k/2.
+			// We also assert that k <= n/2, so i will be at most n/4.
+			// n/4 is always smaller than the vector length n. qed.
+			*unsafe { elm_data.get_unchecked_mut(i) } = Additive(Elt::from_be_bytes([
+				bytes.get(2 * i).copied().unwrap_or_default(),
+				bytes.get(2 * i + 1).copied().unwrap_or_default(),
+			]));
+		}
 	}
 
 	// update new data bytes with zero padded bytes
@@ -242,10 +288,26 @@ pub fn encode_sub_faster8(bytes: &[u8], n: usize, k: usize) -> Result<Vec<Additi
 	let mut elm_data = vec![Additive(0); n];
 
 	for i in 0..(bytes_len / 2) {
-		elm_data[i] = Additive(Elt::from_be_bytes([
-			bytes.get(2 * i).map(|x| *x).unwrap_or_default(),
-			bytes.get(2 * i + 1).map(|x| *x).unwrap_or_default(),
-		]))
+		#[cfg(debug)]
+		{
+			elm_data[i] = Additive(Elt::from_be_bytes([
+				bytes.get(2 * i).copied().unwrap_or_default(),
+				bytes.get(2 * i + 1).copied().unwrap_or_default(),
+			]));
+		}
+		#[cfg(not(debug))]
+		{
+			// SAFETY
+			//
+			// i is used to index `elm_data`, which is preallocated to n elements.
+			// i goes from 0 (bytes.len() / 2) and we assert that bytes.len() <= k/2.
+			// We also assert that k <= n/2, so i will be at most n/4.
+			// n/4 is always smaller than the vector length n. qed.
+			*unsafe { elm_data.get_unchecked_mut(i) } = Additive(Elt::from_be_bytes([
+				bytes.get(2 * i).copied().unwrap_or_default(),
+				bytes.get(2 * i + 1).copied().unwrap_or_default(),
+			]));
+		}
 	}
 
 	// update new data bytes with zero padded bytes

--- a/reed-solomon-novelpoly/src/field/inc_encode.rs
+++ b/reed-solomon-novelpoly/src/field/inc_encode.rs
@@ -76,17 +76,7 @@ pub fn encode_low_faster8(data: &[Additive], k: usize, codeword: &mut [Additive]
 	// denoted `M_topdash`
 
 	for shift in (k..n).step_by(k) {
-		#[cfg(debug)]
 		let codeword_at_shift = &mut codeword_skip_first_k[(shift - k)..shift];
-
-		#[cfg(not(debug))]
-		// SAFETY
-		//
-		// n is i*k, with i at least 2. shift is at most (i-1)*k.
-		// (i-1) * k will always be smaller than i*k for all i greater than 2.
-		// Similarly, shift - k will always be smaller than shift, since they're positive integers
-		// and shift is at least equal to k.
-		let codeword_at_shift = unsafe { codeword_skip_first_k.get_unchecked_mut((shift - k)..shift) };
 
 		// copy `M_topdash` to the position we are currently at, the n transform
 		codeword_at_shift.copy_from_slice(codeword_first_k);
@@ -249,26 +239,10 @@ pub fn encode_sub_faster8(bytes: &[u8], n: usize, k: usize) -> Result<Vec<Additi
 	let mut elm_data = vec![Additive(0); n];
 
 	for i in 0..((bytes_len + 1) / 2) {
-		#[cfg(debug)]
-		{
-			elm_data[i] = Additive(Elt::from_be_bytes([
-				bytes.get(2 * i).copied().unwrap_or_default(),
-				bytes.get(2 * i + 1).copied().unwrap_or_default(),
-			]));
-		}
-		#[cfg(not(debug))]
-		{
-			// SAFETY
-			//
-			// i is used to index `elm_data`, which is preallocated to n elements.
-			// i goes from 0 (bytes.len() / 2) and we assert that bytes.len() <= k/2.
-			// We also assert that k <= n/2, so i will be at most n/4.
-			// n/4 is always smaller than the vector length n. qed.
-			*unsafe { elm_data.get_unchecked_mut(i) } = Additive(Elt::from_be_bytes([
-				bytes.get(2 * i).copied().unwrap_or_default(),
-				bytes.get(2 * i + 1).copied().unwrap_or_default(),
-			]));
-		}
+		elm_data[i] = Additive(Elt::from_be_bytes([
+			bytes.get(2 * i).copied().unwrap_or_default(),
+			bytes.get(2 * i + 1).copied().unwrap_or_default(),
+		]));
 	}
 
 	// update new data bytes with zero padded bytes

--- a/reed-solomon-novelpoly/src/field/inc_log_mul.rs
+++ b/reed-solomon-novelpoly/src/field/inc_log_mul.rs
@@ -82,9 +82,9 @@ impl std::fmt::Display for Multiplier {
 /// Fast Walsh–Hadamard transform over modulo `ONEMASK`
 #[inline(always)]
 pub fn walsh(data: &mut [Multiplier], size: usize) {
-	#[cfg(all(target_feature = "avx", table_bootstrap_complete))]
+	#[cfg(all(target_feature = "avx", table_bootstrap_complete, feature = "avx"))]
 	walsh_faster8(data, size);
-	#[cfg(not(all(target_feature = "avx", table_bootstrap_complete)))]
+	#[cfg(not(all(target_feature = "avx", table_bootstrap_complete, feature = "avx")))]
 	walsh_plain(data, size);
 }
 

--- a/reed-solomon-novelpoly/src/field/inc_log_mul.rs
+++ b/reed-solomon-novelpoly/src/field/inc_log_mul.rs
@@ -59,6 +59,7 @@ impl Additive {
 
 /// Multiplicaiton friendly LOG form of f2e16
 #[derive(Clone, Debug, Copy, Add, AddAssign, Sub, SubAssign, PartialEq, Eq)] // Default, PartialOrd,Ord
+#[repr(transparent)]
 pub struct Multiplier(pub Elt);
 
 impl Multiplier {

--- a/reed-solomon-novelpoly/src/field/inc_log_mul.rs
+++ b/reed-solomon-novelpoly/src/field/inc_log_mul.rs
@@ -88,7 +88,10 @@ pub fn walsh(data: &mut [Multiplier], size: usize) {
 	walsh_plain(data, size);
 }
 
+#[inline(always)]
 pub fn walsh_plain(data: &mut [Multiplier], size: usize) {
+	assert!(data.len() >= size);
+
 	let mask = ONEMASK as Wide;
 	let mut depart_no = 1_usize;
 	while depart_no < size {

--- a/reed-solomon-novelpoly/src/field/inc_reconstruct.rs
+++ b/reed-solomon-novelpoly/src/field/inc_reconstruct.rs
@@ -69,15 +69,27 @@ pub(crate) fn decode_main(
 	assert!(n >= recover_up_to);
 	assert_eq!(erasure.len(), n);
 
-	for i in 0..n {
+	for i in 0..codeword.len() {
 		codeword[i] = if erasure[i] { Additive(0) } else { codeword[i].mul(log_walsh2[i]) };
 	}
 
-	inverse_afft(codeword, n, 0);
+	// SAFETY
+	//
+	// - safe because we check in `reconstruct_sub` that n is a power of two and we also check that
+	// codeword.len() is equal to n.
+	// - n is at most 65536. `index + size - 2` is therefore equal to 65536 - 2 = 65534 which
+	// is less than or equal to 65534. qed.
+	unsafe { inverse_afft(codeword, n, 0) };
 
-	tweaked_formal_derivative(codeword, n);
+	tweaked_formal_derivative(codeword);
 
-	afft(codeword, n, 0);
+	// SAFETY
+	//
+	// - safe because we check in `reconstruct_sub` that n is a power of two and we also check that
+	// codeword.len() is equal to n.
+	// - n is at most 65536. `index + size - 2` is therefore equal to 65536 - 2 = 65534 which
+	// is less than or equal to 65534. qed.
+	unsafe { afft(codeword, n, 0) };
 
 	for i in 0..recover_up_to {
 		codeword[i] = if erasure[i] { codeword[i].mul(log_walsh2[i]) } else { Additive(0) };

--- a/reed-solomon-novelpoly/src/field/inc_reconstruct.rs
+++ b/reed-solomon-novelpoly/src/field/inc_reconstruct.rs
@@ -73,23 +73,11 @@ pub(crate) fn decode_main(
 		codeword[i] = if erasure[i] { Additive(0) } else { codeword[i].mul(log_walsh2[i]) };
 	}
 
-	// SAFETY
-	//
-	// - safe because we check in `reconstruct_sub` that n is a power of two and we also check that
-	// codeword.len() is equal to n.
-	// - n is at most 65536. `index + size - 2` is therefore equal to 65536 - 2 = 65534 which
-	// is less than or equal to 65534. qed.
-	unsafe { inverse_afft(codeword, n, 0) };
+	inverse_afft(codeword, n, 0);
 
 	tweaked_formal_derivative(codeword);
 
-	// SAFETY
-	//
-	// - safe because we check in `reconstruct_sub` that n is a power of two and we also check that
-	// codeword.len() is equal to n.
-	// - n is at most 65536. `index + size - 2` is therefore equal to 65536 - 2 = 65534 which
-	// is less than or equal to 65534. qed.
-	unsafe { afft(codeword, n, 0) };
+	afft(codeword, n, 0);
 
 	for i in 0..recover_up_to {
 		codeword[i] = if erasure[i] { codeword[i].mul(log_walsh2[i]) } else { Additive(0) };
@@ -101,6 +89,10 @@ pub(crate) fn decode_main(
 // since this has only to be called once per reconstruction
 pub fn eval_error_polynomial(erasure: &[bool], log_walsh2: &mut [Multiplier], n: usize) {
 	let z = std::cmp::min(n, erasure.len());
+	assert!(z <= erasure.len());
+	assert!(n <= log_walsh2.len());
+	assert!(z <= log_walsh2.len());
+
 	for i in 0..z {
 		log_walsh2[i] = Multiplier(erasure[i] as Elt);
 	}

--- a/reed-solomon-novelpoly/src/novel_poly_basis/mod.rs
+++ b/reed-solomon-novelpoly/src/novel_poly_basis/mod.rs
@@ -66,7 +66,7 @@ impl CodeParams {
 		{
 			self.k >= (Additive8x::LANE << 1) && self.n % Additive8x::LANE == 0
 		}
-		#[cfg(not(target_feature = "avx"))]
+		#[cfg(not(all(target_feature = "avx", feature = "avx")))]
 		false
 	}
 

--- a/reed-solomon-novelpoly/src/novel_poly_basis/tests.rs
+++ b/reed-solomon-novelpoly/src/novel_poly_basis/tests.rs
@@ -69,12 +69,12 @@ fn flt_back_and_forth() {
 	let mut data = (0..N).map(|_x| rand_gf_element()).collect::<Vec<Additive>>();
 	let expected = data.clone();
 
-	afft(&mut data, N, N / 4);
+	unsafe { afft(&mut data, N, N / 4) };
 
 	// make sure something is done
 	assert!(data.iter().zip(expected.iter()).filter(|(a, b)| { a != b }).count() > 0);
 
-	inverse_afft(&mut data, N, N / 4);
+	unsafe { inverse_afft(&mut data, N, N / 4) };
 
 	itertools::assert_equal(data, expected);
 }
@@ -313,7 +313,7 @@ fn flt_roundtrip_small() {
 
 	let mut data = EXPECTED;
 
-	f2e16::afft(&mut data, N, N / 4);
+	unsafe { f2e16::afft(&mut data, N, N / 4) };
 
 	println!("novel basis(rust):");
 	data.iter().for_each(|sym| {
@@ -321,7 +321,7 @@ fn flt_roundtrip_small() {
 	});
 	println!();
 
-	f2e16::inverse_afft(&mut data, N, N / 4);
+	unsafe { f2e16::inverse_afft(&mut data, N, N / 4) };
 	itertools::assert_equal(data.iter(), EXPECTED.iter());
 }
 
@@ -351,12 +351,7 @@ fn ported_c_test() {
 	//---------encoding----------
 	let mut codeword = [Additive(0); N];
 
-	if K + K > N && false {
-		let (data_till_t, data_skip_t) = data.split_at_mut(N - K);
-		f2e16::encode_high(data_skip_t, K, data_till_t, &mut codeword[..], N);
-	} else {
-		f2e16::encode_low(&data[..], K, &mut codeword[..], N);
-	}
+	f2e16::encode_low(&data[..], K, &mut codeword[..], N);
 
 	// println!("Codeword:");
 	// for i in K..(K+100) {

--- a/reed-solomon-novelpoly/src/novel_poly_basis/tests.rs
+++ b/reed-solomon-novelpoly/src/novel_poly_basis/tests.rs
@@ -352,7 +352,12 @@ fn ported_c_test() {
 	//---------encoding----------
 	let mut codeword = [Additive(0); N];
 
-	f2e16::encode_low(&data[..], K, &mut codeword[..], N);
+	if K + K > N && false {
+		let (data_till_t, data_skip_t) = data.split_at_mut(N - K);
+		f2e16::encode_high(data_skip_t, K, data_till_t, &mut codeword[..], N);
+	} else {
+		f2e16::encode_low(&data[..], K, &mut codeword[..], N);
+	}
 
 	// println!("Codeword:");
 	// for i in K..(K+100) {

--- a/reed-solomon-novelpoly/src/novel_poly_basis/tests.rs
+++ b/reed-solomon-novelpoly/src/novel_poly_basis/tests.rs
@@ -70,12 +70,12 @@ fn flt_back_and_forth() {
 	let mut data = (0..N).map(|_x| rand_gf_element()).collect::<Vec<Additive>>();
 	let expected = data.clone();
 
-	unsafe { afft(&mut data, N, N / 4) };
+	afft(&mut data, N, N / 4);
 
 	// make sure something is done
 	assert!(data.iter().zip(expected.iter()).filter(|(a, b)| { a != b }).count() > 0);
 
-	unsafe { inverse_afft(&mut data, N, N / 4) };
+	inverse_afft(&mut data, N, N / 4);
 
 	itertools::assert_equal(data, expected);
 }
@@ -314,7 +314,7 @@ fn flt_roundtrip_small() {
 
 	let mut data = EXPECTED;
 
-	unsafe { f2e16::afft(&mut data, N, N / 4) };
+	f2e16::afft(&mut data, N, N / 4);
 
 	println!("novel basis(rust):");
 	data.iter().for_each(|sym| {
@@ -322,7 +322,7 @@ fn flt_roundtrip_small() {
 	});
 	println!();
 
-	unsafe { f2e16::inverse_afft(&mut data, N, N / 4) };
+	f2e16::inverse_afft(&mut data, N, N / 4);
 	itertools::assert_equal(data.iter(), EXPECTED.iter());
 }
 


### PR DESCRIPTION
This brings a performance improvement of 20-30%.

Where possible, compiler is aided to optimise away the bounds checks without any unsafe code. No unsafe code was used.

This PR does not touch AVX code, because when testing, I did not see a noticeable improvement for that case.

Numbers before:

```
~~~ [ Benchmark case: 1000000 bytes ] ~~~
Encode RUST (10 cycles): 397.182 ms
Decode RUST (10 cycles): 961.006 ms
Encode C++ (10 cycles): 221.003 ms
Decode C++ (10 cycles): 572.489 ms

~~~ [ Benchmark case: 2500000 bytes ] ~~~
Encode RUST (10 cycles): 1018.27 ms
Decode RUST (10 cycles): 2424.6 ms
Encode C++ (10 cycles): 602.386 ms
Decode C++ (10 cycles): 1459.45 ms

~~~ [ Benchmark case: 5000000 bytes ] ~~~
Encode RUST (10 cycles): 2043.65 ms
Decode RUST (10 cycles): 4813.27 ms
Encode C++ (10 cycles): 1208.36 ms
Decode C++ (10 cycles): 2892.14 ms

~~~ [ Benchmark case: 10000000 bytes ] ~~~
Encode RUST (10 cycles): 4095.26 ms
Decode RUST (10 cycles): 9.61965 s
Encode C++ (10 cycles): 2416.67 ms
Decode C++ (10 cycles): 5.76792 s
```

Numbers now:

```
~~~ [ Benchmark case: 1000000 bytes ] ~~~
Encode RUST (10 cycles): 335.291 ms -> 18.5% better than master
Decode RUST (10 cycles): 739.528 ms -> 30% better than master
Encode C++ (10 cycles): 211.608 ms
Decode C++ (10 cycles): 562.939 ms

~~~ [ Benchmark case: 2500000 bytes ] ~~~
Encode RUST (10 cycles): 855.59 ms -> 19% better than master
Decode RUST (10 cycles): 1830.64 ms -> 32% better than master
Encode C++ (10 cycles): 559.997 ms
Decode C++ (10 cycles): 1434.1 ms

~~~ [ Benchmark case: 5000000 bytes ] ~~~
Encode RUST (10 cycles): 1730.34 ms -> 18% better than master
Decode RUST (10 cycles): 3633.53 ms -> 32% better than master
Encode C++ (10 cycles): 1177.38 ms
Decode C++ (10 cycles): 2863.14 ms

~~~ [ Benchmark case: 10000000 bytes ] ~~~
Encode RUST (10 cycles): 3475.36 ms -> 17.8% better than master
Decode RUST (10 cycles): 7.25712 s -> 32.5% better than master
Encode C++ (10 cycles): 2372.91 ms
Decode C++ (10 cycles): 5.7262 s
```

The only thing preventing from this implementation being as fast as kagome's C++ impl are the few lines annotated with:
```
// TODO: Optimising bounds checks on this line will yield a great performance improvement.
```

I couldn't yet manage to get the compiler to ellide the bounds checks in those cases. Another way of achieving this would be to add a bit of unsafe code.